### PR TITLE
Database expansion (update proofing)

### DIFF
--- a/src/main/java/me/deadlight/ezchestshop/Commands/Ecsadmin.java
+++ b/src/main/java/me/deadlight/ezchestshop/Commands/Ecsadmin.java
@@ -1,6 +1,7 @@
 package me.deadlight.ezchestshop.Commands;
 
 import me.deadlight.ezchestshop.Data.Config;
+import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.Data.LanguageManager;
 import me.deadlight.ezchestshop.Utils.Utils;
@@ -262,7 +263,7 @@ public class Ecsadmin implements CommandExecutor, TabCompleter {
                                 container.set(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING, "none");
                                 container.set(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER, 1);
 
-
+                                ShopContainer.createShop(block.getLocation(), player, thatItem, buyprice, sellprice, false, false, false, "none", true, "none", true);
                                 //msgtoggle 0/1
                                 //dbuy 0/1
                                 //dsell 0/1

--- a/src/main/java/me/deadlight/ezchestshop/Commands/MainCommands.java
+++ b/src/main/java/me/deadlight/ezchestshop/Commands/MainCommands.java
@@ -196,7 +196,7 @@ public class MainCommands implements CommandExecutor, TabCompleter {
                             //adminshop 0/1
                             Utils.storeItem(thatItem, container);
                             state.update();
-                            ShopContainer.createShop(block.getLocation(), player);
+                            ShopContainer.createShop(block.getLocation(), player, thatItem, buyprice, sellprice, false, false, false, "none", true, "none", false);
 
                             player.sendMessage(lm.shopCreated());
 

--- a/src/main/java/me/deadlight/ezchestshop/Data/SQLite/Database.java
+++ b/src/main/java/me/deadlight/ezchestshop/Data/SQLite/Database.java
@@ -188,6 +188,43 @@ public abstract class Database {
         return 0;
     }
 
+    /**
+     * Query the Database for a Double value
+     *
+     * @param primary_key the name of the primary key row.
+     * @param key the value of the primary key that is to query
+     * @param column the name of the column whose data needs to be queried
+     * @param table the table that is to be queried
+     * @return the resulting long or 0
+     */
+    public double getDouble(String primary_key, String key, String column, String table) {
+        Connection conn = null;
+        PreparedStatement ps = null;
+        ResultSet rs;
+        try {
+            conn = getSQLConnection();
+            ps = conn.prepareStatement("SELECT * FROM " + table + " WHERE " + primary_key + " = ?;");
+            ps.setString(1, key);
+
+            rs = ps.executeQuery();
+            if (rs.next()) {
+                return rs.getDouble(column);
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, Errors.sqlConnectionExecute(), e);
+        } finally {
+            try {
+                if (ps != null)
+                    ps.close();
+                if (conn != null)
+                    conn.close();
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, Errors.sqlConnectionClose(), e);
+            }
+        }
+        return 0;
+    }
+
 
     /**
      * Set a String in the Database.
@@ -266,6 +303,40 @@ public abstract class Database {
             ps = conn.prepareStatement("UPDATE " + table + " SET " + column + " = ? WHERE " + primary_key
                     + " = ?;");
             ps.setInt(1, data);
+            ps.setString(2, key);
+
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, Errors.sqlConnectionExecute(), e);
+        } finally {
+            try {
+                if (ps != null)
+                    ps.close();
+                if (conn != null)
+                    conn.close();
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, Errors.sqlConnectionClose(), e);
+            }
+        }
+    }
+
+    /**
+     * Set a Double in the Database.
+     *
+     * @param primary_key the name of the primary key row.
+     * @param key the value of the primary key that is to query
+     * @param column the name of the column whose data needs to be queried
+     * @param table the table that is to be queried
+     * @param data the int to be set
+     */
+    public void setDouble(String primary_key, String key, String column, String table, double data) {
+        Connection conn = null;
+        PreparedStatement ps = null;
+        try {
+            conn = getSQLConnection();
+            ps = conn.prepareStatement("UPDATE " + table + " SET " + column + " = ? WHERE " + primary_key
+                    + " = ?;");
+            ps.setDouble(1, data);
             ps.setString(2, key);
 
             ps.executeUpdate();

--- a/src/main/java/me/deadlight/ezchestshop/Data/SQLite/SQLite.java
+++ b/src/main/java/me/deadlight/ezchestshop/Data/SQLite/SQLite.java
@@ -93,6 +93,17 @@ public class SQLite extends Database {
                 {
                     put("location", new SQLColumn("STRING (32)", true, false));
                     put("owner", new SQLColumn("STRING (32)", false, false));
+                    put("item", new SQLColumn("STRING (32)", false, false));
+                    put("buyPrice", new SQLColumn("DOUBLE", false, false));
+                    put("sellPrice", new SQLColumn("DOUBLE", false, false));
+                    put("msgToggle", new SQLColumn("BOOLEAN", false, false));
+                    put("buyDisabled", new SQLColumn("BOOLEAN", false, false));
+                    put("sellDisabled", new SQLColumn("BOOLEAN", false, false));
+                    put("admins", new SQLColumn("STRING (32)", false, false));
+                    put("shareIncome", new SQLColumn("BOOLEAN", false, false));
+                    put("transactions", new SQLColumn("STRING (32)", false, false));
+                    put("adminshop", new SQLColumn("BOOLEAN", false, false));
+
                 }
             }));
             return tables;

--- a/src/main/java/me/deadlight/ezchestshop/GUIs/SettingsGUI.java
+++ b/src/main/java/me/deadlight/ezchestshop/GUIs/SettingsGUI.java
@@ -1,10 +1,12 @@
 package me.deadlight.ezchestshop.GUIs;
 
+import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.Data.LanguageManager;
 import me.deadlight.ezchestshop.Listeners.ChatListener;
 import me.deadlight.ezchestshop.Utils.Objects.ChatWaitObject;
 import me.deadlight.ezchestshop.Utils.LogType;
+import me.deadlight.ezchestshop.Utils.Objects.ShopSettings;
 import me.deadlight.ezchestshop.Utils.Utils;
 import dev.triumphteam.gui.guis.Gui;
 import dev.triumphteam.gui.guis.GuiItem;
@@ -100,6 +102,7 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(toggleMessageChooser(false, lm));
                 event.getCurrentItem().setItemMeta(meta);
+                ShopContainer.getShopSettings(rightChest.getLocation()).setMsgtoggle(false);
             } else {
                 rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER, 1);
                 rightChest.update();
@@ -108,6 +111,7 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(toggleMessageChooser(true, lm));
                 event.getCurrentItem().setItemMeta(meta);
+                ShopContainer.getShopSettings(rightChest.getLocation()).setMsgtoggle(true);
 
             }
         });
@@ -130,6 +134,7 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(buyMessageChooser(false, lm));
                 event.getCurrentItem().setItemMeta(meta);
+                ShopContainer.getShopSettings(rightChest.getLocation()).setDbuy(false);
             } else {
                 rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER, 1);
                 rightChest.update();
@@ -138,6 +143,7 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(buyMessageChooser(true, lm));
                 event.getCurrentItem().setItemMeta(meta);
+                ShopContainer.getShopSettings(rightChest.getLocation()).setDbuy(true);
             }
 
         });
@@ -159,6 +165,8 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(sellMessageChooser(false, lm));
                 event.getCurrentItem().setItemMeta(meta);
+
+                ShopContainer.getShopSettings(rightChest.getLocation()).setDsell(false);
             } else {
                 rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER, 1);
                 rightChest.update();
@@ -167,6 +175,7 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(sellMessageChooser(true, lm));
                 event.getCurrentItem().setItemMeta(meta);
+                ShopContainer.getShopSettings(rightChest.getLocation()).setDsell(true);
             }
         });
 
@@ -217,6 +226,7 @@ public class SettingsGUI {
                     ItemMeta meta = event.getCurrentItem().getItemMeta();
                     meta.setLore(shareIncomeLoreChooser(false, lm));
                     event.getCurrentItem().setItemMeta(meta);
+                    ShopContainer.getShopSettings(rightChest.getLocation()).setShareincome(false);
                 } else {
                     rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER, 1);
                     rightChest.update();
@@ -225,6 +235,7 @@ public class SettingsGUI {
                     ItemMeta meta = event.getCurrentItem().getItemMeta();
                     meta.setLore(shareIncomeLoreChooser(true, lm));
                     event.getCurrentItem().setItemMeta(meta);
+                    ShopContainer.getShopSettings(rightChest.getLocation()).setShareincome(true);
                 }
 
 

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/ChatListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/ChatListener.java
@@ -1,4 +1,5 @@
 package me.deadlight.ezchestshop.Listeners;
+import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.GUIs.SettingsGUI;
 import me.deadlight.ezchestshop.Data.LanguageManager;
@@ -121,7 +122,9 @@ public class ChatListener implements Listener {
             PersistentDataContainer data = rightChest.getPersistentDataContainer();
             data.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING, adminsString);
             rightChest.update();
+            ShopContainer.getShopSettings(rightChest.getLocation()).setAdmins(adminsString);
             player.sendMessage(lm.sucAdminAdded(answer));
+
 
         } else {
             player.sendMessage(lm.alreadyAdmin());
@@ -146,6 +149,7 @@ public class ChatListener implements Listener {
             PersistentDataContainer data = rightChest.getPersistentDataContainer();
             data.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING, adminsString);
             rightChest.update();
+            ShopContainer.getShopSettings(rightChest.getLocation()).setAdmins(adminsString);
             player.sendMessage(lm.sucAdminRemoved(answer));
 
         } else {

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/ChestOpeningEvent.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/ChestOpeningEvent.java
@@ -1,4 +1,5 @@
 package me.deadlight.ezchestshop.Listeners;
+import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.GUIs.AdminShopGUI;
 import me.deadlight.ezchestshop.GUIs.NonOwnerShopGUI;
@@ -66,6 +67,14 @@ public class ChestOpeningEvent implements Listener {
                         insertNewValues(rightChest);
                         rightone = rightChest.getPersistentDataContainer();
 
+
+                        EzChestShop.getPlugin().logConsole("Clicking Chest");
+                        // Load old shops into the Database when clicked
+                        if (!ShopContainer.isShop(rightChest.getLocation())) {
+                            ShopContainer.loadShop(rightChest);
+                            EzChestShop.getPlugin().logConsole("Loaded old Chest");
+                        }
+
                         //String owner = Bukkit.getOfflinePlayer(UUID.fromString(rightone.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING))).getName();
                         String owneruuid = rightone.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING);
                         boolean isAdminShop = rightone.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER) == 1;
@@ -104,6 +113,14 @@ public class ChestOpeningEvent implements Listener {
 
                         ownerValueConvertor(chest);
                         insertNewValues(chest);
+
+                        EzChestShop.getPlugin().logConsole("Clicking Chest");
+                        // Load old shops into the Database when clicked
+                        if (!ShopContainer.isShop(chest.getLocation())) {
+                            ShopContainer.loadShop(chest);
+                            EzChestShop.getPlugin().logConsole("Loaded old Chest");
+                        }
+
                         container = chest.getPersistentDataContainer();
                         boolean isAdminShop = container.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER) == 1;
                         //String owner = Bukkit.getOfflinePlayer(UUID.fromString(container.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING))).getName();

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
@@ -34,9 +34,6 @@ public class PlayerCloseToChestListener implements Listener {
 
     public static HashMap<Player, List<ASHologramObject>> map = new HashMap<>();
 
-    public static boolean showholo = EzChestShop.getPlugin().getConfig().getBoolean("show-holograms");
-    public static String firstLine = EzChestShop.getPlugin().getConfig().getString("hologram-first-line");
-    public static String secondLine = EzChestShop.getPlugin().getConfig().getString("hologram-second-line");
     private static HashMap<Location, String> playershopmap = new HashMap<>();
 
     @EventHandler
@@ -137,13 +134,13 @@ public class PlayerCloseToChestListener implements Listener {
         } else {
             itemname = thatItem.getType().name();
         }
-        String finalfirstline = Utils.color(firstLine.replace("%item%", itemname).replace("%buy%", String.valueOf(buy)).replace("%sell%", String.valueOf(sell)));
+        String finalfirstline = Utils.color(Config.firstLine.replace("%item%", itemname).replace("%buy%", String.valueOf(buy)).replace("%sell%", String.valueOf(sell)));
 
         ASHologram hologram = new ASHologram(player, finalfirstline, EntityType.ARMOR_STAND, secondLineLocation, false);
         hologram.spawn();
         Utils.onlinePackets.add(hologram);
 
-        ASHologram hologram2 = new ASHologram(player, Utils.color(secondLine.replace("%buy%", String.valueOf(buy)).replace("%sell%", String.valueOf(sell)).replace("%item%", itemname)), EntityType.ARMOR_STAND, thirdLocation, false);
+        ASHologram hologram2 = new ASHologram(player, Utils.color(Config.secondLine.replace("%buy%", String.valueOf(buy)).replace("%sell%", String.valueOf(sell)).replace("%item%", itemname)), EntityType.ARMOR_STAND, thirdLocation, false);
         hologram2.spawn();
         Utils.onlinePackets.add(hologram2);
 

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerTransactionListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerTransactionListener.java
@@ -1,4 +1,5 @@
 package me.deadlight.ezchestshop.Listeners;
+import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.Utils.Objects.TransactionLogObject;
 import me.deadlight.ezchestshop.Utils.Utils;
@@ -90,6 +91,7 @@ public class PlayerTransactionListener implements Listener {
 
         data.set(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING, finalString.toString());
         event.getChest().update();
+        ShopContainer.getShopSettings(event.getChest().getLocation()).setTrans(finalString.toString());
 
     }
 

--- a/src/main/java/me/deadlight/ezchestshop/Utils/Objects/ShopSettings.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/Objects/ShopSettings.java
@@ -1,0 +1,105 @@
+package me.deadlight.ezchestshop.Utils.Objects;
+
+import me.deadlight.ezchestshop.Data.SQLite.Database;
+import me.deadlight.ezchestshop.EzChestShop;
+
+public class ShopSettings {
+
+    private String sloc;
+    private boolean msgtoggle;
+    private boolean dbuy;
+    private boolean dsell;
+    private String admins;
+    private boolean shareincome;
+    private String trans;
+    private boolean adminshop;
+
+    public ShopSettings(String sloc, boolean msgtoggle, boolean dbuy, boolean dsell, String admins, boolean shareincome,
+                        String trans, boolean adminshop) {
+        this.sloc = sloc;
+        this.msgtoggle = msgtoggle;
+        this.dbuy = dbuy;
+        this.dsell = dsell;
+        this.admins = admins;
+        this.shareincome = shareincome;
+        this.trans = trans;
+        this.adminshop = adminshop;
+    }
+
+    public boolean isMsgtoggle() {
+        return msgtoggle;
+    }
+
+    public void setMsgtoggle(boolean msgtoggle) {
+        this.msgtoggle = msgtoggle;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setBool("location", sloc,
+                "msgToggle", "shopdata", msgtoggle);
+    }
+
+    public boolean isDbuy() {
+        return dbuy;
+    }
+
+    public void setDbuy(boolean dbuy) {
+        this.dbuy = dbuy;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setBool("location", sloc,
+                "buyDisabled", "shopdata", dbuy);
+    }
+
+    public boolean isDsell() {
+        return dsell;
+    }
+
+    public void setDsell(boolean dsell) {
+        this.dsell = dsell;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setBool("location", sloc,
+                "sellDisabled", "shopdata", dsell);
+    }
+
+    public String getAdmins() {
+        return admins;
+    }
+
+    public void setAdmins(String admins) {
+        this.admins = admins;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setString("location", sloc,
+                "admins", "shopdata", admins);
+    }
+
+    public boolean isShareincome() {
+        return shareincome;
+    }
+
+    public void setShareincome(boolean shareincome) {
+        this.shareincome = shareincome;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setBool("location", sloc,
+                "shareIncome", "shopdata", shareincome);
+    }
+
+    public String getTrans() {
+        return trans;
+    }
+
+    public void setTrans(String trans) {
+        this.trans = trans;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setString("location", sloc,
+                "transactions", "shopdata", trans);
+    }
+
+    public boolean isAdminshop() {
+        return adminshop;
+    }
+
+    public void setAdminshop(boolean adminshop) {
+        this.adminshop = adminshop;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setBool("location", sloc,
+                "adminshop", "shopdata", adminshop);
+    }
+}

--- a/src/main/java/me/deadlight/ezchestshop/Utils/Utils.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/Utils.java
@@ -38,6 +38,15 @@ public class Utils {
 
     public static void storeItem(ItemStack item, PersistentDataContainer data) throws IOException {
 
+        String encodedItem = encodeItem(item);
+        if (encodedItem != null) {
+            data.set(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING, encodedItem);
+        }
+
+
+    }
+
+    public static String encodeItem(ItemStack item) {
         try {
             ByteArrayOutputStream io = new ByteArrayOutputStream();
             BukkitObjectOutputStream os = new BukkitObjectOutputStream(io);
@@ -49,14 +58,13 @@ public class Utils {
 
             String encodedData = Base64.getEncoder().encodeToString(rawData);
 
-            data.set(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING, encodedData);
             os.close();
+           return encodedData;
 
         } catch (IOException ex) {
             System.out.println(ex);
+            return null;
         }
-
-
     }
 
     public static ItemStack getItem(String encodedItem) {


### PR DESCRIPTION
- added additional columns to store all the data that is being stored in the chests in the database too.
- added < 1.3.3 updater. Data of old chestshops is saved to the database once clicked in 1.3.3 >
- added Double support to the Database
- added admin shop support to the distance based holograms
- added Shop settings Object (for future projects like copying Settings or Storing whole Shops in memory)
- fixed Config hologram message issues in PlayerCloseToChestListener (was still using the old system)
- split the  Item encoding method in Utils up, in order to access the resulting String for the database.