### PR TITLE
Shulker&Barrel Support

### DIFF
--- a/src/main/java/me/deadlight/ezchestshop/Commands/Ecsadmin.java
+++ b/src/main/java/me/deadlight/ezchestshop/Commands/Ecsadmin.java
@@ -1,6 +1,7 @@
 package me.deadlight.ezchestshop.Commands;
 
 import me.deadlight.ezchestshop.Data.Config;
+import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.Data.LanguageManager;
 import me.deadlight.ezchestshop.Utils.Utils;
@@ -262,7 +263,7 @@ public class Ecsadmin implements CommandExecutor, TabCompleter {
                                 container.set(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING, "none");
                                 container.set(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER, 1);
 
-
+                                ShopContainer.createShop(block.getLocation(), player, thatItem, buyprice, sellprice, false, false, false, "none", true, "none", true);
                                 //msgtoggle 0/1
                                 //dbuy 0/1
                                 //dsell 0/1

--- a/src/main/java/me/deadlight/ezchestshop/Commands/Ecsadmin.java
+++ b/src/main/java/me/deadlight/ezchestshop/Commands/Ecsadmin.java
@@ -139,12 +139,12 @@ public class Ecsadmin implements CommandExecutor, TabCompleter {
             BlockState blockState = block.getState();
             if (blockState instanceof TileState) {
 
-                if (block.getType() == Material.CHEST) {
+                if (Utils.isApplicableContainer(block)) {
 
                         TileState state = (TileState) blockState;
 
                         PersistentDataContainer container = ((TileState) blockState).getPersistentDataContainer();
-                        Chest chkIfDCS = ifItsADoubleChestShop((Chest) block.getState());
+                        Chest chkIfDCS = ifItsADoubleChestShop(block);
 
                         if (container.has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || chkIfDCS != null) {
 
@@ -222,7 +222,7 @@ public class Ecsadmin implements CommandExecutor, TabCompleter {
 
             if (blockState instanceof TileState) {
 
-                if (block.getType() == Material.CHEST) {
+                if (Utils.isApplicableContainer(block)) {
 
                         TileState state = (TileState) blockState;
 
@@ -234,11 +234,9 @@ public class Ecsadmin implements CommandExecutor, TabCompleter {
                         //item (String) (itemstack)
 
                         //already a shop
-                        if (container.has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || ifItsADoubleChestShop((Chest) block.getState()) != null) {
+                        if (container.has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || ifItsADoubleChestShop(block) != null) {
 
                             player.sendMessage(lm.alreadyAShop());
-                            ifItsADoubleChestShop((Chest) block.getState());
-
 
                         } else {
                             //not a shop
@@ -304,35 +302,30 @@ public class Ecsadmin implements CommandExecutor, TabCompleter {
         }
     }
 
-    private Chest ifItsADoubleChestShop(Chest chest) {
+    private Chest ifItsADoubleChestShop(Block block) {
         //double chest
-        Inventory inventory = chest.getInventory();
-        if (inventory instanceof DoubleChestInventory) {
-            DoubleChest doubleChest = (DoubleChest) chest.getInventory().getHolder();
-            Chest leftchest = (Chest) doubleChest.getLeftSide();
-            Chest rightchest = (Chest) doubleChest.getRightSide();
+        if (block instanceof Chest) {
+            Chest chest = (Chest) block.getState();
+            Inventory inventory = chest.getInventory();
+            if (inventory instanceof DoubleChestInventory) {
+                DoubleChest doubleChest = (DoubleChest) chest.getInventory().getHolder();
+                Chest leftchest = (Chest) doubleChest.getLeftSide();
+                Chest rightchest = (Chest) doubleChest.getRightSide();
 
-            if (leftchest.getPersistentDataContainer().has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || rightchest.getPersistentDataContainer().has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING)) {
+                if (leftchest.getPersistentDataContainer().has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || rightchest.getPersistentDataContainer().has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING)) {
 
-                Chest rightone = null;
+                    Chest rightone = null;
 
-                if (!leftchest.getPersistentDataContainer().isEmpty()) {
-                    rightone = leftchest;
-                } else {
-                    rightone = rightchest;
+                    if (!leftchest.getPersistentDataContainer().isEmpty()) {
+                        rightone = leftchest;
+                    } else {
+                        rightone = rightchest;
+                    }
+
+                    return rightone;
                 }
-
-                return rightone;
-            } else {
-                return null;
             }
-        } else {
-            return null;
         }
-
-
+        return null;
     }
-
-
-
 }

--- a/src/main/java/me/deadlight/ezchestshop/Commands/MainCommands.java
+++ b/src/main/java/me/deadlight/ezchestshop/Commands/MainCommands.java
@@ -196,7 +196,7 @@ public class MainCommands implements CommandExecutor, TabCompleter {
                             //adminshop 0/1
                             Utils.storeItem(thatItem, container);
                             state.update();
-                            ShopContainer.createShop(block.getLocation(), player);
+                            ShopContainer.createShop(block.getLocation(), player, thatItem, buyprice, sellprice, false, false, false, "none", true, "none", false);
 
                             player.sendMessage(lm.shopCreated());
 

--- a/src/main/java/me/deadlight/ezchestshop/Commands/MainCommands.java
+++ b/src/main/java/me/deadlight/ezchestshop/Commands/MainCommands.java
@@ -139,7 +139,7 @@ public class MainCommands implements CommandExecutor, TabCompleter {
 
             if (blockState instanceof TileState) {
 
-                if (block.getType() == Material.CHEST) {
+                if (Utils.isApplicableContainer(block)) {
 
                     if (checkIfLocation(block.getLocation(), player)) {
 
@@ -154,11 +154,9 @@ public class MainCommands implements CommandExecutor, TabCompleter {
                     //item (String) (itemstack)
 
                     //already a shop
-                    if (container.has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || ifItsADoubleChestShop((Chest) block.getState()) != null) {
+                    if (container.has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || ifItsADoubleChestShop(block) != null) {
 
                         player.sendMessage(lm.alreadyAShop());
-                        ifItsADoubleChestShop((Chest) block.getState());
-
 
                     } else {
                         //not a shop
@@ -238,7 +236,7 @@ public class MainCommands implements CommandExecutor, TabCompleter {
             BlockState blockState = block.getState();
             if (blockState instanceof TileState) {
 
-                if (block.getType() == Material.CHEST) {
+                if (Utils.isApplicableContainer(block)) {
 
                     if (checkIfLocation(block.getLocation(), player)) {
 
@@ -246,7 +244,7 @@ public class MainCommands implements CommandExecutor, TabCompleter {
                     TileState state = (TileState) blockState;
 
                     PersistentDataContainer container = ((TileState) blockState).getPersistentDataContainer();
-                    Chest chkIfDCS = ifItsADoubleChestShop((Chest) block.getState());
+                    Chest chkIfDCS = ifItsADoubleChestShop(block);
 
                     if (container.has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || chkIfDCS != null) {
 
@@ -351,7 +349,7 @@ public class MainCommands implements CommandExecutor, TabCompleter {
         } // End of WildChests integration (future integration)
 
         Block exactBlock = player.getTargetBlockExact(6);
-        if (exactBlock == null || exactBlock.getType() == Material.AIR || exactBlock.getType() != Material.CHEST) {
+        if (exactBlock == null || exactBlock.getType() == Material.AIR || !(Utils.isApplicableContainer(exactBlock))) {
             return false;
         }
 
@@ -380,33 +378,31 @@ public class MainCommands implements CommandExecutor, TabCompleter {
         }
     }
 
-    private Chest ifItsADoubleChestShop(Chest chest) {
+    private Chest ifItsADoubleChestShop(Block block) {
             //double chest
-        Inventory inventory = chest.getInventory();
-        if (inventory instanceof DoubleChestInventory) {
-            DoubleChest doubleChest = (DoubleChest) chest.getInventory().getHolder();
-            Chest leftchest = (Chest) doubleChest.getLeftSide();
-            Chest rightchest = (Chest) doubleChest.getRightSide();
+        if (block instanceof Chest) {
+            Chest chest = (Chest) block.getState();
+            Inventory inventory = chest.getInventory();
+            if (inventory instanceof DoubleChestInventory) {
+                DoubleChest doubleChest = (DoubleChest) chest.getInventory().getHolder();
+                Chest leftchest = (Chest) doubleChest.getLeftSide();
+                Chest rightchest = (Chest) doubleChest.getRightSide();
 
-            if (leftchest.getPersistentDataContainer().has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || rightchest.getPersistentDataContainer().has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING)) {
+                if (leftchest.getPersistentDataContainer().has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || rightchest.getPersistentDataContainer().has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING)) {
 
-                Chest rightone = null;
+                    Chest rightone = null;
 
-                if (!leftchest.getPersistentDataContainer().isEmpty()) {
-                    rightone = leftchest;
-                } else {
-                    rightone = rightchest;
+                    if (!leftchest.getPersistentDataContainer().isEmpty()) {
+                        rightone = leftchest;
+                    } else {
+                        rightone = rightchest;
+                    }
+
+                    return rightone;
                 }
-
-                return rightone;
-            } else {
-                return null;
             }
-        } else {
-            return null;
         }
-
-
+        return null;
     }
 
     private void checkForNewValues(PersistentDataContainer dataContainer, boolean forceInsert) {

--- a/src/main/java/me/deadlight/ezchestshop/Data/Config.java
+++ b/src/main/java/me/deadlight/ezchestshop/Data/Config.java
@@ -12,6 +12,9 @@ public class Config {
     public static int holodelay;
     public static boolean holodistancing;
     public static double holodistancing_distance;
+    public static boolean container_chests;
+    public static boolean container_barrels;
+    public static boolean container_shulkers;
 
 
     public static void loadConfig() {
@@ -20,6 +23,7 @@ public class Config {
         EzChestShop.getPlugin().reloadConfig();
         FileConfiguration config = EzChestShop.getPlugin().getConfig();
         currency = config.getString("economy.server-currency");
+
         showholo = config.getBoolean("hologram.show-holograms");
         firstLine = config.getString("hologram.hologram-first-line");
         secondLine = config.getString("hologram.hologram-second-line").replace("%currency%", Config.currency);
@@ -27,6 +31,9 @@ public class Config {
         holodistancing = config.getBoolean("hologram.distance.toggled");
         holodistancing_distance = config.getDouble("hologram.distance.range");
 
+        container_chests = config.getBoolean("container.chests");
+        container_barrels = config.getBoolean("container.barrels");
+        container_shulkers = config.getBoolean("container.shulkers");
 
     }
 }

--- a/src/main/java/me/deadlight/ezchestshop/Data/SQLite/Database.java
+++ b/src/main/java/me/deadlight/ezchestshop/Data/SQLite/Database.java
@@ -188,6 +188,43 @@ public abstract class Database {
         return 0;
     }
 
+    /**
+     * Query the Database for a Double value
+     *
+     * @param primary_key the name of the primary key row.
+     * @param key the value of the primary key that is to query
+     * @param column the name of the column whose data needs to be queried
+     * @param table the table that is to be queried
+     * @return the resulting long or 0
+     */
+    public double getDouble(String primary_key, String key, String column, String table) {
+        Connection conn = null;
+        PreparedStatement ps = null;
+        ResultSet rs;
+        try {
+            conn = getSQLConnection();
+            ps = conn.prepareStatement("SELECT * FROM " + table + " WHERE " + primary_key + " = ?;");
+            ps.setString(1, key);
+
+            rs = ps.executeQuery();
+            if (rs.next()) {
+                return rs.getDouble(column);
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, Errors.sqlConnectionExecute(), e);
+        } finally {
+            try {
+                if (ps != null)
+                    ps.close();
+                if (conn != null)
+                    conn.close();
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, Errors.sqlConnectionClose(), e);
+            }
+        }
+        return 0;
+    }
+
 
     /**
      * Set a String in the Database.
@@ -266,6 +303,40 @@ public abstract class Database {
             ps = conn.prepareStatement("UPDATE " + table + " SET " + column + " = ? WHERE " + primary_key
                     + " = ?;");
             ps.setInt(1, data);
+            ps.setString(2, key);
+
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, Errors.sqlConnectionExecute(), e);
+        } finally {
+            try {
+                if (ps != null)
+                    ps.close();
+                if (conn != null)
+                    conn.close();
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, Errors.sqlConnectionClose(), e);
+            }
+        }
+    }
+
+    /**
+     * Set a Double in the Database.
+     *
+     * @param primary_key the name of the primary key row.
+     * @param key the value of the primary key that is to query
+     * @param column the name of the column whose data needs to be queried
+     * @param table the table that is to be queried
+     * @param data the int to be set
+     */
+    public void setDouble(String primary_key, String key, String column, String table, double data) {
+        Connection conn = null;
+        PreparedStatement ps = null;
+        try {
+            conn = getSQLConnection();
+            ps = conn.prepareStatement("UPDATE " + table + " SET " + column + " = ? WHERE " + primary_key
+                    + " = ?;");
+            ps.setDouble(1, data);
             ps.setString(2, key);
 
             ps.executeUpdate();

--- a/src/main/java/me/deadlight/ezchestshop/Data/SQLite/SQLite.java
+++ b/src/main/java/me/deadlight/ezchestshop/Data/SQLite/SQLite.java
@@ -93,6 +93,17 @@ public class SQLite extends Database {
                 {
                     put("location", new SQLColumn("STRING (32)", true, false));
                     put("owner", new SQLColumn("STRING (32)", false, false));
+                    put("item", new SQLColumn("STRING (32)", false, false));
+                    put("buyPrice", new SQLColumn("DOUBLE", false, false));
+                    put("sellPrice", new SQLColumn("DOUBLE", false, false));
+                    put("msgToggle", new SQLColumn("BOOLEAN", false, false));
+                    put("buyDisabled", new SQLColumn("BOOLEAN", false, false));
+                    put("sellDisabled", new SQLColumn("BOOLEAN", false, false));
+                    put("admins", new SQLColumn("STRING (32)", false, false));
+                    put("shareIncome", new SQLColumn("BOOLEAN", false, false));
+                    put("transactions", new SQLColumn("STRING (32)", false, false));
+                    put("adminshop", new SQLColumn("BOOLEAN", false, false));
+
                 }
             }));
             return tables;

--- a/src/main/java/me/deadlight/ezchestshop/Data/ShopContainer.java
+++ b/src/main/java/me/deadlight/ezchestshop/Data/ShopContainer.java
@@ -95,10 +95,9 @@ public class ShopContainer {
         shops.add(loc);
     }
 
-    public static void loadShop(Chest chest) {
+    public static void loadShop(Location loc, PersistentDataContainer dataContainer) {
         Database db = EzChestShop.getPlugin().getDatabase();
-        String sloc = Utils.LocationtoString(chest.getLocation());
-        PersistentDataContainer dataContainer = chest.getPersistentDataContainer();
+        String sloc = Utils.LocationtoString(loc);
 
         boolean msgtoggle = dataContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER) == 1;
         boolean dbuy = dataContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER) == 1;
@@ -133,8 +132,8 @@ public class ShopContainer {
         db.setBool("location", sloc,
                 "adminshop", "shopdata", adminshop);
         ShopSettings settings = new ShopSettings(sloc, msgtoggle, dbuy, dsell, admins, shareincome, trans, adminshop);
-        shopSettings.put(chest.getLocation(), settings);
-        shops.add(chest.getLocation());
+        shopSettings.put(loc, settings);
+        shops.add(loc);
     }
 
     /**

--- a/src/main/java/me/deadlight/ezchestshop/EzChestShop.java
+++ b/src/main/java/me/deadlight/ezchestshop/EzChestShop.java
@@ -98,6 +98,7 @@ public final class EzChestShop extends JavaPlugin {
     private void registerListeners() {
         getServer().getPluginManager().registerEvents(new ChestOpeningEvent(), this);
         getServer().getPluginManager().registerEvents(new BlockBreakListener(), this);
+        getServer().getPluginManager().registerEvents(new BlockPlaceListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerTransactionListener(), this);
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
         //Add Config check over here, to change the Shop display varient.

--- a/src/main/java/me/deadlight/ezchestshop/GUIs/LogsGUI.java
+++ b/src/main/java/me/deadlight/ezchestshop/GUIs/LogsGUI.java
@@ -7,6 +7,7 @@ import me.deadlight.ezchestshop.Utils.Utils;
 import dev.triumphteam.gui.guis.Gui;
 import dev.triumphteam.gui.guis.GuiItem;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -25,7 +26,7 @@ public class LogsGUI {
 
     }
 
-    public void showGUI(Player player, PersistentDataContainer data, Chest chest, LogType type, boolean isAdmin) {
+    public void showGUI(Player player, PersistentDataContainer data, Block chest, LogType type, boolean isAdmin) {
         LanguageManager lm = new LanguageManager();
         String guititle;
         if (type == LogType.TRANSACTION) {
@@ -46,7 +47,7 @@ public class LogsGUI {
         GuiItem doorItem = new GuiItem(door, event -> {
            event.setCancelled(true);
            OwnerShopGUI ownerShopGUI = new OwnerShopGUI();
-           ownerShopGUI.showGUI(player, data, chest, chest, isAdmin);
+           ownerShopGUI.showGUI(player, data, chest, isAdmin);
         });
 
 

--- a/src/main/java/me/deadlight/ezchestshop/GUIs/NonOwnerShopGUI.java
+++ b/src/main/java/me/deadlight/ezchestshop/GUIs/NonOwnerShopGUI.java
@@ -9,7 +9,9 @@ import dev.triumphteam.gui.guis.GuiItem;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import org.bukkit.*;
+import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
+import org.bukkit.block.TileState;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -27,7 +29,7 @@ public class NonOwnerShopGUI {
 
     public NonOwnerShopGUI() {}
 
-    public void showGUI(Player player, PersistentDataContainer data, Chest chest) {
+    public void showGUI(Player player, PersistentDataContainer data, Block chest) {
         LanguageManager lm = new LanguageManager();
 
         String shopOwner = Bukkit.getOfflinePlayer(UUID.fromString(data.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING))).getName();
@@ -157,13 +159,13 @@ public class NonOwnerShopGUI {
 
 
 
-    private void buyItem(Chest chest, double price, int count, Player player, ItemStack tthatItem, OfflinePlayer owner, PersistentDataContainer data) {
+    private void buyItem(Block chest, double price, int count, Player player, ItemStack tthatItem, OfflinePlayer owner, PersistentDataContainer data) {
         ItemStack thatItem = tthatItem.clone();
 
         LanguageManager lm = new LanguageManager();
         //check for money
 
-        if (chest.getInventory().containsAtLeast(thatItem , count)) {
+        if (Utils.getBlockInventory(chest).containsAtLeast(thatItem , count)) {
 
             if (ifHasMoney(Bukkit.getOfflinePlayer(player.getUniqueId()), price)) {
 
@@ -172,9 +174,9 @@ public class NonOwnerShopGUI {
                     thatItem.setAmount(count);
                     getandgive(Bukkit.getOfflinePlayer(player.getUniqueId()), price, owner);
                     sharedIncomeCheck(data, price);
-                    chest.getInventory().removeItem(thatItem);
+                    Utils.getBlockInventory(chest).removeItem(thatItem);
                     player.getInventory().addItem(thatItem);
-                    transactionMessage(data, owner, player, price, true, getFinalItemName(tthatItem), count, (Chest) chest.getLocation().getBlock().getState());
+                    transactionMessage(data, owner, player, price, true, getFinalItemName(tthatItem), count, chest.getLocation().getBlock());
                     player.sendMessage(lm.messageSuccBuy(price));
                     player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_BELL, 0.5f, 0.5f);
 
@@ -197,7 +199,7 @@ public class NonOwnerShopGUI {
 
     }
 
-    private void sellItem(Chest chest, double price, int count, ItemStack tthatItem , OfflinePlayer owner, Player player, PersistentDataContainer data) {
+    private void sellItem(Block chest, double price, int count, ItemStack tthatItem , OfflinePlayer owner, Player player, PersistentDataContainer data) {
 
         LanguageManager lm = new LanguageManager();
 
@@ -207,12 +209,12 @@ public class NonOwnerShopGUI {
 
             if (ifHasMoney(owner, price)) {
 
-                if (chest.getInventory().firstEmpty() != -1) {
+                if (Utils.getBlockInventory(chest).firstEmpty() != -1) {
                     thatItem.setAmount(count);
                     getandgive(owner, price, Bukkit.getOfflinePlayer(player.getUniqueId()));
-                    transactionMessage(data, owner, Bukkit.getOfflinePlayer(player.getUniqueId()), price, false, getFinalItemName(tthatItem), count, (Chest) chest.getLocation().getBlock().getState());
+                    transactionMessage(data, owner, Bukkit.getOfflinePlayer(player.getUniqueId()), price, false, getFinalItemName(tthatItem), count, chest.getLocation().getBlock());
                     player.getInventory().removeItem(thatItem);
-                    chest.getInventory().addItem(thatItem);
+                    Utils.getBlockInventory(chest).addItem(thatItem);
                     player.sendMessage(lm.messageSuccSell(price));
                     player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_BELL, 0.5f, 0.5f);
 
@@ -252,7 +254,7 @@ public class NonOwnerShopGUI {
 
     }
 
-    private void transactionMessage(PersistentDataContainer data, OfflinePlayer owner, OfflinePlayer customer, double price, boolean isBuy, String itemName, int count, Chest chest) {
+    private void transactionMessage(PersistentDataContainer data, OfflinePlayer owner, OfflinePlayer customer, double price, boolean isBuy, String itemName, int count, Block chest) {
 
             //kharidan? true forokhtan? false
             PlayerTransactEvent transactEvent = new PlayerTransactEvent(owner, customer, price, isBuy, itemName, count, Utils.getAdminsList(data), chest);

--- a/src/main/java/me/deadlight/ezchestshop/GUIs/OwnerShopGUI.java
+++ b/src/main/java/me/deadlight/ezchestshop/GUIs/OwnerShopGUI.java
@@ -7,6 +7,7 @@ import dev.triumphteam.gui.guis.Gui;
 import dev.triumphteam.gui.guis.GuiItem;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.*;
+import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.block.DoubleChest;
 import org.bukkit.entity.Player;
@@ -30,7 +31,7 @@ public class OwnerShopGUI {
     public OwnerShopGUI() {}
 
 
-    public void showGUI(Player player, PersistentDataContainer data, Chest chest, Chest rightChest, boolean isAdmin) {
+    public void showGUI(Player player, PersistentDataContainer data, Block chest, boolean isAdmin) {
 
         LanguageManager lm = new LanguageManager();
 
@@ -140,7 +141,7 @@ public class OwnerShopGUI {
 
         GuiItem storageGUI = new GuiItem(storageitem, event -> {
             event.setCancelled(true);
-            Inventory lastinv = chest.getInventory();
+            Inventory lastinv = Utils.getBlockInventory(chest);
             if (lastinv instanceof DoubleChestInventory) {
                 DoubleChest doubleChest = (DoubleChest) lastinv.getHolder();
                 lastinv = doubleChest.getInventory();
@@ -159,7 +160,7 @@ public class OwnerShopGUI {
            event.setCancelled(true);
            //opening the settigns menu
             SettingsGUI settingsGUI = new SettingsGUI();
-            settingsGUI.ShowGUI(player, rightChest, isAdmin);
+            settingsGUI.ShowGUI(player, chest, isAdmin);
             player.playSound(player.getLocation(), Sound.BLOCK_PISTON_EXTEND, 0.5f, 0.5f);
         });
 

--- a/src/main/java/me/deadlight/ezchestshop/GUIs/ServerShopGUI.java
+++ b/src/main/java/me/deadlight/ezchestshop/GUIs/ServerShopGUI.java
@@ -8,7 +8,9 @@ import dev.triumphteam.gui.guis.Gui;
 import dev.triumphteam.gui.guis.GuiItem;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.*;
+import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
+import org.bukkit.block.TileState;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -22,13 +24,13 @@ import java.util.UUID;
 public class ServerShopGUI {
 
     private Economy econ = EzChestShop.getEconomy();
-    private Chest chest;
+    private Block chest;
     public ServerShopGUI() {
 
     }
 
-    public void showGUI(Player player, PersistentDataContainer data, Chest chest, Chest rightChest) {
-        this.chest = rightChest;
+    public void showGUI(Player player, PersistentDataContainer data, Block chest) {
+        this.chest = chest;
         LanguageManager lm = new LanguageManager();
 
         String owneruuid = data.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING);
@@ -133,7 +135,7 @@ public class ServerShopGUI {
         settingsMeta.setDisplayName(lm.settingsButton());
         settingsItem.setItemMeta(settingsMeta);
 
-        boolean result = isAdmin(rightChest.getPersistentDataContainer(), player.getUniqueId().toString());
+        boolean result = isAdmin(((TileState)chest.getState()).getPersistentDataContainer(), player.getUniqueId().toString());
         //place moved vvv because of settingsGUI
         gui.getFiller().fillBorder(glasses);
 
@@ -143,7 +145,7 @@ public class ServerShopGUI {
                 //opening the settigns menu
                 SettingsGUI settingsGUI = new SettingsGUI();
 
-                settingsGUI.ShowGUI(player, rightChest, result);
+                settingsGUI.ShowGUI(player, chest, result);
                 player.playSound(player.getLocation(), Sound.BLOCK_PISTON_EXTEND, 0.5f, 0.5f);
             });
 

--- a/src/main/java/me/deadlight/ezchestshop/GUIs/SettingsGUI.java
+++ b/src/main/java/me/deadlight/ezchestshop/GUIs/SettingsGUI.java
@@ -14,7 +14,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
+import org.bukkit.block.TileState;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
@@ -35,11 +37,11 @@ public class SettingsGUI {
     //trans [list of infos seperated by @ in string form]
     //adminshop 0/1
 
-    public void ShowGUI(Player player, Chest rightChest, boolean isAdmin) {
+    public void ShowGUI(Player player, Block chest, boolean isAdmin) {
 
         LanguageManager lm = new LanguageManager();
 
-        PersistentDataContainer dataContainer = rightChest.getPersistentDataContainer();
+        PersistentDataContainer dataContainer = ((TileState)chest.getState()).getPersistentDataContainer();
 
         boolean isAdminShop = dataContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER) == 1;
 
@@ -64,7 +66,7 @@ public class SettingsGUI {
         GuiItem lastTrans = new GuiItem(lastTransItem, event -> {
            event.setCancelled(true);
            LogsGUI logsGUI = new LogsGUI();
-           logsGUI.showGUI(player, dataContainer, rightChest, LogType.TRANSACTION, isAdmin);
+           logsGUI.showGUI(player, dataContainer, chest, LogType.TRANSACTION, isAdmin);
         });
 
         //I was going to add logs section which would be about actions in that chest shop but I decided not to implement it. maybe later
@@ -94,24 +96,25 @@ public class SettingsGUI {
             event.setCancelled(true);
             //start the functionality for toggle message
             if (checkIfOn(event.getCurrentItem().getType())) {
-
-                rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER, 0);
-                rightChest.update();
+                TileState state = ((TileState)chest.getState());
+                state.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER, 0);
+                state.update();
                 player.sendMessage(lm.toggleTransactionMessageOffInChat());
                 event.getCurrentItem().setType(Material.GRAY_DYE);
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(toggleMessageChooser(false, lm));
                 event.getCurrentItem().setItemMeta(meta);
-                ShopContainer.getShopSettings(rightChest.getLocation()).setMsgtoggle(false);
+                ShopContainer.getShopSettings(chest.getLocation()).setMsgtoggle(false);
             } else {
-                rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER, 1);
-                rightChest.update();
+                TileState state = ((TileState)chest.getState());
+                state.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER, 1);
+                state.update();
                 player.sendMessage(lm.toggleTransactionMessageOnInChat());
                 event.getCurrentItem().setType(Material.LIME_DYE);
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(toggleMessageChooser(true, lm));
                 event.getCurrentItem().setItemMeta(meta);
-                ShopContainer.getShopSettings(rightChest.getLocation()).setMsgtoggle(true);
+                ShopContainer.getShopSettings(chest.getLocation()).setMsgtoggle(true);
 
             }
         });
@@ -127,23 +130,25 @@ public class SettingsGUI {
             event.setCancelled(true);
             //start the functionality for disabling buy
             if (checkIfOn(event.getCurrentItem().getType())) {
-                rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER, 0);
-                rightChest.update();
+                TileState state = ((TileState)chest.getState());
+                state.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER, 0);
+                state.update();
                 player.sendMessage(lm.disableBuyingOffInChat());
                 event.getCurrentItem().setType(Material.GRAY_DYE);
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(buyMessageChooser(false, lm));
                 event.getCurrentItem().setItemMeta(meta);
-                ShopContainer.getShopSettings(rightChest.getLocation()).setDbuy(false);
+                ShopContainer.getShopSettings(chest.getLocation()).setDbuy(false);
             } else {
-                rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER, 1);
-                rightChest.update();
+                TileState state = ((TileState)chest.getState());
+                state.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER, 1);
+                state.update();
                 player.sendMessage(lm.disableBuyingOnInChat());
                 event.getCurrentItem().setType(Material.LIME_DYE);
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(buyMessageChooser(true, lm));
                 event.getCurrentItem().setItemMeta(meta);
-                ShopContainer.getShopSettings(rightChest.getLocation()).setDbuy(true);
+                ShopContainer.getShopSettings(chest.getLocation()).setDbuy(true);
             }
 
         });
@@ -158,24 +163,25 @@ public class SettingsGUI {
             event.setCancelled(true);
             //start the functionality for disabling sell
             if (checkIfOn(event.getCurrentItem().getType())) {
-                rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER, 0);
-                rightChest.update();
+                TileState state = ((TileState)chest.getState());
+                state.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER, 0);
+                state.update();
                 player.sendMessage(lm.disableSellingOffInChat());
                 event.getCurrentItem().setType(Material.GRAY_DYE);
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(sellMessageChooser(false, lm));
                 event.getCurrentItem().setItemMeta(meta);
-
-                ShopContainer.getShopSettings(rightChest.getLocation()).setDsell(false);
+                ShopContainer.getShopSettings(chest.getLocation()).setDsell(false);
             } else {
-                rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER, 1);
-                rightChest.update();
+                TileState state = ((TileState)chest.getState());
+                state.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER, 1);
+                state.update();
                 player.sendMessage(lm.disableSellingOnInChat());
                 event.getCurrentItem().setType(Material.LIME_DYE);
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(sellMessageChooser(true, lm));
                 event.getCurrentItem().setItemMeta(meta);
-                ShopContainer.getShopSettings(rightChest.getLocation()).setDsell(true);
+                ShopContainer.getShopSettings(chest.getLocation()).setDsell(true);
             }
         });
 
@@ -195,14 +201,14 @@ public class SettingsGUI {
                 if (event.getClick() == ClickType.LEFT) {
                     //left click == add admin
 
-                    ChatListener.chatmap.put(player.getUniqueId(), new ChatWaitObject("none", "add", rightChest));
+                    ChatListener.chatmap.put(player.getUniqueId(), new ChatWaitObject("none", "add", chest));
                     player.closeInventory();
                     player.sendMessage(lm.addingAdminWaiting());
 
 
                 } else if (event.getClick() == ClickType.RIGHT) {
                     //right click == remove admin
-                    ChatListener.chatmap.put(player.getUniqueId(), new ChatWaitObject("none", "remove", rightChest));
+                    ChatListener.chatmap.put(player.getUniqueId(), new ChatWaitObject("none", "remove", chest));
                     player.closeInventory();
                     player.sendMessage(lm.removingAdminWaiting());
                 }
@@ -219,23 +225,25 @@ public class SettingsGUI {
                 //start the functionality for shared income
 
                 if (checkIfOn(event.getCurrentItem().getType())) {
-                    rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER, 0);
-                    rightChest.update();
+                    TileState state = ((TileState)chest.getState());
+                    state.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER, 0);
+                    state.update();
                     player.sendMessage(lm.sharedIncomeOffInChat());
                     event.getCurrentItem().setType(Material.GRAY_DYE);
                     ItemMeta meta = event.getCurrentItem().getItemMeta();
                     meta.setLore(shareIncomeLoreChooser(false, lm));
                     event.getCurrentItem().setItemMeta(meta);
-                    ShopContainer.getShopSettings(rightChest.getLocation()).setShareincome(false);
+                    ShopContainer.getShopSettings(chest.getLocation()).setShareincome(false);
                 } else {
-                    rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER, 1);
-                    rightChest.update();
+                    TileState state = ((TileState)chest.getState());
+                    state.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER, 1);
+                    state.update();
                     player.sendMessage(lm.sharedIncomeOnInChat());
                     event.getCurrentItem().setType(Material.LIME_DYE);
                     ItemMeta meta = event.getCurrentItem().getItemMeta();
                     meta.setLore(shareIncomeLoreChooser(true, lm));
                     event.getCurrentItem().setItemMeta(meta);
-                    ShopContainer.getShopSettings(rightChest.getLocation()).setShareincome(true);
+                    ShopContainer.getShopSettings(chest.getLocation()).setShareincome(true);
                 }
 
 
@@ -263,19 +271,19 @@ public class SettingsGUI {
 
             if (isAdminShop) {
                 ServerShopGUI serverShopGUI = new ServerShopGUI();
-                serverShopGUI.showGUI(player, dataContainer, rightChest, rightChest);
+                serverShopGUI.showGUI(player, dataContainer, chest);
                 return;
             }
 
             if (player.getUniqueId().toString().equalsIgnoreCase(owneruuid) || isAdmin) {
                 if (player.hasPermission("ecs.admin")) {
                     AdminShopGUI adminShopGUI = new AdminShopGUI();
-                    adminShopGUI.showGUI(player, dataContainer, rightChest, rightChest);
+                    adminShopGUI.showGUI(player, dataContainer, chest);
                     return;
                 }
                 //owner show special gui
                 OwnerShopGUI ownerShopGUI = new OwnerShopGUI();
-                ownerShopGUI.showGUI(player, dataContainer, rightChest, rightChest, isAdmin);
+                ownerShopGUI.showGUI(player, dataContainer, chest, isAdmin);
 
 
             } else {
@@ -284,7 +292,7 @@ public class SettingsGUI {
                 //just in case, i check again for player's permission
                 if (player.hasPermission("ecs.admin")) {
                     AdminShopGUI adminShopGUI = new AdminShopGUI();
-                    adminShopGUI.showGUI(player, dataContainer, rightChest, rightChest);
+                    adminShopGUI.showGUI(player, dataContainer, chest);
                 } else {
                     player.closeInventory();
                 }

--- a/src/main/java/me/deadlight/ezchestshop/GUIs/SettingsGUI.java
+++ b/src/main/java/me/deadlight/ezchestshop/GUIs/SettingsGUI.java
@@ -1,10 +1,12 @@
 package me.deadlight.ezchestshop.GUIs;
 
+import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.Data.LanguageManager;
 import me.deadlight.ezchestshop.Listeners.ChatListener;
 import me.deadlight.ezchestshop.Utils.Objects.ChatWaitObject;
 import me.deadlight.ezchestshop.Utils.LogType;
+import me.deadlight.ezchestshop.Utils.Objects.ShopSettings;
 import me.deadlight.ezchestshop.Utils.Utils;
 import dev.triumphteam.gui.guis.Gui;
 import dev.triumphteam.gui.guis.GuiItem;
@@ -100,6 +102,7 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(toggleMessageChooser(false, lm));
                 event.getCurrentItem().setItemMeta(meta);
+                ShopContainer.getShopSettings(rightChest.getLocation()).setMsgtoggle(false);
             } else {
                 rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER, 1);
                 rightChest.update();
@@ -108,6 +111,7 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(toggleMessageChooser(true, lm));
                 event.getCurrentItem().setItemMeta(meta);
+                ShopContainer.getShopSettings(rightChest.getLocation()).setMsgtoggle(true);
 
             }
         });
@@ -130,6 +134,7 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(buyMessageChooser(false, lm));
                 event.getCurrentItem().setItemMeta(meta);
+                ShopContainer.getShopSettings(rightChest.getLocation()).setDbuy(false);
             } else {
                 rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER, 1);
                 rightChest.update();
@@ -138,6 +143,7 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(buyMessageChooser(true, lm));
                 event.getCurrentItem().setItemMeta(meta);
+                ShopContainer.getShopSettings(rightChest.getLocation()).setDbuy(true);
             }
 
         });
@@ -159,6 +165,8 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(sellMessageChooser(false, lm));
                 event.getCurrentItem().setItemMeta(meta);
+
+                ShopContainer.getShopSettings(rightChest.getLocation()).setDsell(false);
             } else {
                 rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER, 1);
                 rightChest.update();
@@ -167,6 +175,7 @@ public class SettingsGUI {
                 ItemMeta meta = event.getCurrentItem().getItemMeta();
                 meta.setLore(sellMessageChooser(true, lm));
                 event.getCurrentItem().setItemMeta(meta);
+                ShopContainer.getShopSettings(rightChest.getLocation()).setDsell(true);
             }
         });
 
@@ -217,6 +226,7 @@ public class SettingsGUI {
                     ItemMeta meta = event.getCurrentItem().getItemMeta();
                     meta.setLore(shareIncomeLoreChooser(false, lm));
                     event.getCurrentItem().setItemMeta(meta);
+                    ShopContainer.getShopSettings(rightChest.getLocation()).setShareincome(false);
                 } else {
                     rightChest.getPersistentDataContainer().set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER, 1);
                     rightChest.update();
@@ -225,6 +235,7 @@ public class SettingsGUI {
                     ItemMeta meta = event.getCurrentItem().getItemMeta();
                     meta.setLore(shareIncomeLoreChooser(true, lm));
                     event.getCurrentItem().setItemMeta(meta);
+                    ShopContainer.getShopSettings(rightChest.getLocation()).setShareincome(true);
                 }
 
 

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/BlockBreakListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/BlockBreakListener.java
@@ -1,15 +1,22 @@
 package me.deadlight.ezchestshop.Listeners;
 
 import me.deadlight.ezchestshop.Data.ShopContainer;
+import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.Utils.Utils;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.TileState;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.Collection;
 
@@ -44,6 +51,42 @@ public class BlockBreakListener implements Listener {
             Location loc = event.getBlock().getLocation();
             if (ShopContainer.isShop(loc)) {
                 ShopContainer.deleteShop(loc);
+                if (Utils.isShulkerBox(event.getBlock())) {
+                    if (event.isDropItems()) {
+                        event.setDropItems(false);
+                        ItemStack shulker = event.getBlock().getDrops().stream().findFirst().get();
+                        ItemMeta meta = shulker.getItemMeta();
+                        PersistentDataContainer container = meta.getPersistentDataContainer();
+                        PersistentDataContainer bcontainer = ((TileState) event.getBlock().getState()).getPersistentDataContainer();
+                        if (bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) != null) {
+                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING,
+                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING));
+                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "buy"), PersistentDataType.DOUBLE,
+                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "buy"), PersistentDataType.DOUBLE));
+                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "sell"), PersistentDataType.DOUBLE,
+                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "sell"), PersistentDataType.DOUBLE));
+                            //add new settings data later
+                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER,
+                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER));
+                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER,
+                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER));
+                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER,
+                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER));
+                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING,
+                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING));
+                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER,
+                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER));
+                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING,
+                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING));
+                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER,
+                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER));
+                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING,
+                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING));
+                            shulker.setItemMeta(meta);
+                            loc.getWorld().dropItemNaturally(loc, shulker);
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/BlockPlaceListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/BlockPlaceListener.java
@@ -1,0 +1,66 @@
+package me.deadlight.ezchestshop.Listeners;
+
+import me.deadlight.ezchestshop.Data.ShopContainer;
+import me.deadlight.ezchestshop.EzChestShop;
+import me.deadlight.ezchestshop.Utils.Utils;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
+import org.bukkit.block.TileState;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockDispenseEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+public class BlockPlaceListener implements Listener {
+
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+
+        Block block = event.getBlock();
+        ItemStack item = event.getItemInHand();
+        placeBlock(block, item);
+
+    }
+
+    private void placeBlock(Block block, ItemStack shulker) {
+        if (Utils.isShulkerBox(shulker.getType())) {
+            if (shulker.hasItemMeta()) {
+                ItemMeta meta = shulker.getItemMeta();
+                PersistentDataContainer container = meta.getPersistentDataContainer();
+                if (container.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) != null) {
+                    TileState state = ((TileState) block.getState());
+                    PersistentDataContainer bcontainer = state.getPersistentDataContainer();
+                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING,
+                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING));
+                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "buy"), PersistentDataType.DOUBLE,
+                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "buy"), PersistentDataType.DOUBLE));
+                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "sell"), PersistentDataType.DOUBLE,
+                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "sell"), PersistentDataType.DOUBLE));
+                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER,
+                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER));
+                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER,
+                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER));
+                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER,
+                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER));
+                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING,
+                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING));
+                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER,
+                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER));
+                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING,
+                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING));
+                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER,
+                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER));
+                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING,
+                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING));
+                    state.update();
+                    ShopContainer.loadShop(block.getLocation(), bcontainer);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/ChatListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/ChatListener.java
@@ -1,4 +1,5 @@
 package me.deadlight.ezchestshop.Listeners;
+import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.GUIs.SettingsGUI;
 import me.deadlight.ezchestshop.Data.LanguageManager;
@@ -121,7 +122,9 @@ public class ChatListener implements Listener {
             PersistentDataContainer data = rightChest.getPersistentDataContainer();
             data.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING, adminsString);
             rightChest.update();
+            ShopContainer.getShopSettings(rightChest.getLocation()).setAdmins(adminsString);
             player.sendMessage(lm.sucAdminAdded(answer));
+
 
         } else {
             player.sendMessage(lm.alreadyAdmin());
@@ -146,6 +149,7 @@ public class ChatListener implements Listener {
             PersistentDataContainer data = rightChest.getPersistentDataContainer();
             data.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING, adminsString);
             rightChest.update();
+            ShopContainer.getShopSettings(rightChest.getLocation()).setAdmins(adminsString);
             player.sendMessage(lm.sucAdminRemoved(answer));
 
         } else {

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/ChestOpeningEvent.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/ChestOpeningEvent.java
@@ -6,10 +6,7 @@ import me.deadlight.ezchestshop.GUIs.NonOwnerShopGUI;
 import me.deadlight.ezchestshop.GUIs.OwnerShopGUI;
 import me.deadlight.ezchestshop.GUIs.ServerShopGUI;
 import me.deadlight.ezchestshop.Utils.Utils;
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
-import org.bukkit.OfflinePlayer;
+import org.bukkit.*;
 import org.bukkit.block.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -30,128 +27,76 @@ public class ChestOpeningEvent implements Listener {
 
     @EventHandler
     public void onChestOpening(PlayerInteractEvent event) {
-
-        if (event.getAction() == Action.RIGHT_CLICK_BLOCK && event.getClickedBlock().getType() == Material.CHEST) {
+        if (event.getClickedBlock() == null) return;
+        Material clickedType = event.getClickedBlock().getType();
+        if (event.getAction() == Action.RIGHT_CLICK_BLOCK && (clickedType == Material.CHEST || clickedType == Material.BARREL || Utils.isShulkerBox(clickedType))) {
 
             Block chestblock = event.getClickedBlock();
+            PersistentDataContainer dataContainer = null;
+            Location loc = chestblock.getLocation();
+            TileState state = (TileState) chestblock.getState();
+            Inventory inventory = Utils.getBlockInventory(chestblock);
 
-
-            if (chestblock.getType() == Material.CHEST) {
-
-                TileState state = (TileState) chestblock.getState();
-
-                Chest chest = (Chest) chestblock.getState();
-
-                Inventory inventory = chest.getInventory();
+            if (clickedType == Material.CHEST) {
                 if (inventory instanceof DoubleChestInventory) {
-
-
                     DoubleChest doubleChest = (DoubleChest) inventory.getHolder();
                     Chest chestleft = (Chest) doubleChest.getLeftSide();
                     Chest chestright = (Chest) doubleChest.getRightSide();
 
 
-                    if (chestleft.getPersistentDataContainer().has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || chestright.getPersistentDataContainer().has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING)) {
-
-                        PersistentDataContainer rightone = null;
-                        Chest rightChest = null;
-                        event.setCancelled(true);
-
-                        if (!chestleft.getPersistentDataContainer().isEmpty()) {
-                            rightChest = chestleft;
-                        } else {
-                            rightChest = chestright;
-                        }
-
-                        ownerValueConvertor(rightChest);
-                        insertNewValues(rightChest);
-                        rightone = rightChest.getPersistentDataContainer();
-
-
-                        EzChestShop.getPlugin().logConsole("Clicking Chest");
-                        // Load old shops into the Database when clicked
-                        if (!ShopContainer.isShop(rightChest.getLocation())) {
-                            ShopContainer.loadShop(rightChest);
-                            EzChestShop.getPlugin().logConsole("Loaded old Chest");
-                        }
-
-                        //String owner = Bukkit.getOfflinePlayer(UUID.fromString(rightone.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING))).getName();
-                        String owneruuid = rightone.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING);
-                        boolean isAdminShop = rightone.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER) == 1;
-
-                        if (isAdminShop) {
-                            ServerShopGUI serverShopGUI = new ServerShopGUI();
-                            serverShopGUI.showGUI(event.getPlayer(), rightone, chest, rightChest);
-                            return;
-                        }
-                        boolean isAdmin = isAdmin(rightone, event.getPlayer().getUniqueId().toString());
-
-                        if (event.getPlayer().hasPermission("ecs.admin")) {
-                            adminShopGUI.showGUI(event.getPlayer(), rightone, chest, rightChest);
-                            return;
-                        }
-
-                        if (event.getPlayer().getUniqueId().toString().equalsIgnoreCase(owneruuid) || isAdmin) {
-
-                            ownerShopGUI.showGUI(event.getPlayer(), rightone, chest, rightChest, isAdmin);
-
-                        } else {
-
-                            //not owner show default
-                            nonOwnerShopGUI.showGUI(event.getPlayer(), rightone, chest);
-
-                        }
-
+                    if (!chestleft.getPersistentDataContainer().isEmpty()) {
+                        dataContainer = chestleft.getPersistentDataContainer();
+                        chestblock = chestleft.getBlock();
+                    } else {
+                        dataContainer = chestright.getPersistentDataContainer();
+                        chestblock = chestright.getBlock();
                     }
+                    loc  = chestblock.getLocation();
+                } else {
+                    dataContainer = state.getPersistentDataContainer();
+                }
+            } else if (clickedType == Material.BARREL) {
+                dataContainer = state.getPersistentDataContainer();
+            } else if (Utils.isShulkerBox(clickedType)) {
+                dataContainer = state.getPersistentDataContainer();
+            }
+
+
+            if (dataContainer.has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING)) {
+                event.setCancelled(true);
+                ownerValueConvertor(chestblock);
+                insertNewValues(chestblock);
+
+
+                // Load old shops into the Database when clicked
+                if (!ShopContainer.isShop(loc)) {
+                    ShopContainer.loadShop(loc, dataContainer);
+                }
+
+                //String owner = Bukkit.getOfflinePlayer(UUID.fromString(rightone.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING))).getName();
+                String owneruuid = dataContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING);
+                boolean isAdminShop = dataContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER) == 1;
+
+                if (isAdminShop) {
+                    ServerShopGUI serverShopGUI = new ServerShopGUI();
+                    serverShopGUI.showGUI(event.getPlayer(), dataContainer, chestblock);
+                    return;
+                }
+                boolean isAdmin = isAdmin(dataContainer, event.getPlayer().getUniqueId().toString());
+
+                if (event.getPlayer().hasPermission("ecs.admin")) {
+                    adminShopGUI.showGUI(event.getPlayer(), dataContainer, chestblock);
+                    return;
+                }
+
+                if (event.getPlayer().getUniqueId().toString().equalsIgnoreCase(owneruuid) || isAdmin) {
+
+                    ownerShopGUI.showGUI(event.getPlayer(), dataContainer, chestblock, isAdmin);
 
                 } else {
 
-                    PersistentDataContainer container = state.getPersistentDataContainer();
-
-                    if (container.has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING)) {
-                        event.setCancelled(true);
-
-                        ownerValueConvertor(chest);
-                        insertNewValues(chest);
-
-                        EzChestShop.getPlugin().logConsole("Clicking Chest");
-                        // Load old shops into the Database when clicked
-                        if (!ShopContainer.isShop(chest.getLocation())) {
-                            ShopContainer.loadShop(chest);
-                            EzChestShop.getPlugin().logConsole("Loaded old Chest");
-                        }
-
-                        container = chest.getPersistentDataContainer();
-                        boolean isAdminShop = container.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER) == 1;
-                        //String owner = Bukkit.getOfflinePlayer(UUID.fromString(container.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING))).getName();
-                        String owneruuid = container.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING);
-                        boolean isAdmin = isAdmin(container, event.getPlayer().getUniqueId().toString());
-
-                        if (isAdminShop) {
-                            ServerShopGUI serverShopGUI = new ServerShopGUI();
-                            serverShopGUI.showGUI(event.getPlayer(), container, chest, chest);
-                            return;
-                        }
-
-                        if (event.getPlayer().hasPermission("ecs.admin")) {
-                            adminShopGUI.showGUI(event.getPlayer(), container, chest, chest);
-                            return;
-                        }
-
-                        if (event.getPlayer().getUniqueId().toString().equalsIgnoreCase(owneruuid) || isAdmin) {
-                            //owner show special gui
-                            ownerShopGUI.showGUI(event.getPlayer(), container, chest, chest, isAdmin);
-
-                        } else {
-
-                            //not owner show default
-                            nonOwnerShopGUI.showGUI(event.getPlayer(), container, chest);
-
-                        }
-
-
-
-                    }
+                    //not owner show default
+                    nonOwnerShopGUI.showGUI(event.getPlayer(), dataContainer, chestblock);
 
                 }
 
@@ -161,8 +106,8 @@ public class ChestOpeningEvent implements Listener {
 
     }
 
-    private void ownerValueConvertor(Chest chest) {
-        PersistentDataContainer data = chest.getPersistentDataContainer();
+    private void ownerValueConvertor(Block chest) {
+        PersistentDataContainer data = ((TileState)chest.getState()).getPersistentDataContainer();
         String shopOwner = data.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING);
         try {
             //is UUID
@@ -171,13 +116,13 @@ public class ChestOpeningEvent implements Listener {
             //then its old owner value and I have to change it immediately!
             OfflinePlayer offplayer = Bukkit.getOfflinePlayer(shopOwner);
             data.set(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING, offplayer.getUniqueId().toString());
-            chest.update();
+            chest.getState().update();
         }
     }
 
-    private void insertNewValues(Chest chest) {
+    private void insertNewValues(Block chest) {
         //1.3.0 new values
-        PersistentDataContainer data = chest.getPersistentDataContainer();
+        PersistentDataContainer data = ((TileState)chest.getState()).getPersistentDataContainer();
         if (!data.has(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER)) {
             data.set(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER, 0);
             data.set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER, 0);
@@ -186,7 +131,7 @@ public class ChestOpeningEvent implements Listener {
             data.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING, "none");
             data.set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER, 1);
             data.set(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING, "none");
-            chest.update();
+            chest.getState().update();
         }
     }
 

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/ChestOpeningEvent.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/ChestOpeningEvent.java
@@ -1,4 +1,5 @@
 package me.deadlight.ezchestshop.Listeners;
+import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.GUIs.AdminShopGUI;
 import me.deadlight.ezchestshop.GUIs.NonOwnerShopGUI;
@@ -66,6 +67,14 @@ public class ChestOpeningEvent implements Listener {
                         insertNewValues(rightChest);
                         rightone = rightChest.getPersistentDataContainer();
 
+
+                        EzChestShop.getPlugin().logConsole("Clicking Chest");
+                        // Load old shops into the Database when clicked
+                        if (!ShopContainer.isShop(rightChest.getLocation())) {
+                            ShopContainer.loadShop(rightChest);
+                            EzChestShop.getPlugin().logConsole("Loaded old Chest");
+                        }
+
                         //String owner = Bukkit.getOfflinePlayer(UUID.fromString(rightone.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING))).getName();
                         String owneruuid = rightone.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING);
                         boolean isAdminShop = rightone.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER) == 1;
@@ -104,6 +113,14 @@ public class ChestOpeningEvent implements Listener {
 
                         ownerValueConvertor(chest);
                         insertNewValues(chest);
+
+                        EzChestShop.getPlugin().logConsole("Clicking Chest");
+                        // Load old shops into the Database when clicked
+                        if (!ShopContainer.isShop(chest.getLocation())) {
+                            ShopContainer.loadShop(chest);
+                            EzChestShop.getPlugin().logConsole("Loaded old Chest");
+                        }
+
                         container = chest.getPersistentDataContainer();
                         boolean isAdminShop = container.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER) == 1;
                         //String owner = Bukkit.getOfflinePlayer(UUID.fromString(container.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING))).getName();

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
@@ -10,9 +10,7 @@ import me.deadlight.ezchestshop.Utils.Utils;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.block.Block;
-import org.bukkit.block.Chest;
-import org.bukkit.block.DoubleChest;
+import org.bukkit.block.*;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -53,9 +51,8 @@ public class PlayerCloseToChestListener implements Listener {
 
                     Block target = sloc.getWorld().getBlockAt(sloc);
                     if (target != null) {
-                        if (target.getType() == Material.CHEST) {
-                            Chest chest = (Chest) target.getState();
-                            Inventory inventory = chest.getInventory();
+                        if (Utils.isApplicableContainer(target)) {
+                            Inventory inventory = Utils.getBlockInventory(target);
                             Location holoLoc;
                             if (inventory instanceof DoubleChestInventory) {
                                 DoubleChest doubleChest = (DoubleChest) inventory.getHolder();
@@ -63,10 +60,10 @@ public class PlayerCloseToChestListener implements Listener {
                                 Chest rightchest = (Chest) doubleChest.getRightSide();
                                 holoLoc = leftchest.getLocation().add(0.5D, 0, 0.5D).add(rightchest.getLocation().add(0.5D, 0, 0.5D)).multiply(0.5).add(0, 1, 0);
                             } else {
-                                holoLoc = chest.getLocation().clone().add(0.5, 1, 0.5);
+                                holoLoc = target.getLocation().clone().add(0.5, 1, 0.5);
                             }
 
-                            PersistentDataContainer container = chest.getPersistentDataContainer();
+                            PersistentDataContainer container = ((TileState)target.getState()).getPersistentDataContainer();
                             ItemStack thatItem = Utils.getItem(container.get(new NamespacedKey(EzChestShop.getPlugin(),
                                     "item"), PersistentDataType.STRING));
 

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
@@ -34,9 +34,6 @@ public class PlayerCloseToChestListener implements Listener {
 
     public static HashMap<Player, List<ASHologramObject>> map = new HashMap<>();
 
-    public static boolean showholo = EzChestShop.getPlugin().getConfig().getBoolean("show-holograms");
-    public static String firstLine = EzChestShop.getPlugin().getConfig().getString("hologram-first-line");
-    public static String secondLine = EzChestShop.getPlugin().getConfig().getString("hologram-second-line");
     private static HashMap<Location, String> playershopmap = new HashMap<>();
 
     @EventHandler
@@ -137,13 +134,13 @@ public class PlayerCloseToChestListener implements Listener {
         } else {
             itemname = thatItem.getType().name();
         }
-        String finalfirstline = Utils.color(firstLine.replace("%item%", itemname).replace("%buy%", String.valueOf(buy)).replace("%sell%", String.valueOf(sell)));
+        String finalfirstline = Utils.color(Config.firstLine.replace("%item%", itemname).replace("%buy%", String.valueOf(buy)).replace("%sell%", String.valueOf(sell)));
 
         ASHologram hologram = new ASHologram(player, finalfirstline, EntityType.ARMOR_STAND, secondLineLocation, false);
         hologram.spawn();
         Utils.onlinePackets.add(hologram);
 
-        ASHologram hologram2 = new ASHologram(player, Utils.color(secondLine.replace("%buy%", String.valueOf(buy)).replace("%sell%", String.valueOf(sell)).replace("%item%", itemname)), EntityType.ARMOR_STAND, thirdLocation, false);
+        ASHologram hologram2 = new ASHologram(player, Utils.color(Config.secondLine.replace("%buy%", String.valueOf(buy)).replace("%sell%", String.valueOf(sell)).replace("%item%", itemname)), EntityType.ARMOR_STAND, thirdLocation, false);
         hologram2.spawn();
         Utils.onlinePackets.add(hologram2);
 

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerLookingAtChestShop.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerLookingAtChestShop.java
@@ -8,9 +8,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.block.Block;
-import org.bukkit.block.Chest;
-import org.bukkit.block.DoubleChest;
+import org.bukkit.block.*;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -36,10 +34,9 @@ public class PlayerLookingAtChestShop implements Listener {
         Block target = event.getPlayer().getTargetBlockExact(5);
 
         if (target != null) {
-            if (target.getType() == Material.CHEST) {
+            if (Utils.isApplicableContainer(target)) {
 
-                Chest chest = (Chest) target.getState();
-                Inventory inventory = chest.getInventory();
+                Inventory inventory = Utils.getBlockInventory(target);
                 if (inventory instanceof DoubleChestInventory) {
                     //double chest
 
@@ -73,7 +70,7 @@ public class PlayerLookingAtChestShop implements Listener {
                 } else {
                     //not a double chest
 
-                    PersistentDataContainer container = chest.getPersistentDataContainer();
+                    PersistentDataContainer container = ((TileState)target.getState()).getPersistentDataContainer();
                     if (container.has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING)) {
 
 
@@ -81,7 +78,7 @@ public class PlayerLookingAtChestShop implements Listener {
                         ItemStack thatItem = Utils.getItem(container.get(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING));
                         double buy = container.get(new NamespacedKey(EzChestShop.getPlugin(), "buy"), PersistentDataType.DOUBLE);
                         double sell = container.get(new NamespacedKey(EzChestShop.getPlugin(), "sell"), PersistentDataType.DOUBLE);
-                        Location holoLoc = chest.getLocation().clone().add(0.5, 1, 0.5);
+                        Location holoLoc = target.getLocation().clone().add(0.5, 1, 0.5);
 
                         if (!isAlreadyLooking(event.getPlayer(), target) && Config.showholo && !isAlreadyPresenting(holoLoc, event.getPlayer().getName())) {
                             showHologram(holoLoc,thatItem, buy, sell, event.getPlayer());

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerTransactEvent.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerTransactEvent.java
@@ -1,5 +1,6 @@
 package me.deadlight.ezchestshop.Listeners;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -19,7 +20,7 @@ public class PlayerTransactEvent extends Event {
     private String itemName;
     private int count;
     private List<UUID> admins;
-    private Chest chest;
+    private Block chest;
 
 
     private static final HandlerList HANDLERS = new HandlerList();
@@ -34,7 +35,7 @@ public class PlayerTransactEvent extends Event {
     }
 
 
-    public PlayerTransactEvent(OfflinePlayer owner, OfflinePlayer customer, double price, boolean isBuy, String itemName, int count, List<UUID> admins, Chest chest) {
+    public PlayerTransactEvent(OfflinePlayer owner, OfflinePlayer customer, double price, boolean isBuy, String itemName, int count, List<UUID> admins, Block chest) {
         this.owner = owner;
         this.customer = customer;
         this.price = price;
@@ -76,7 +77,7 @@ public class PlayerTransactEvent extends Event {
     public List<UUID> getAdminsUUID() {
         return this.admins;
     }
-    public Chest getChest() {
+    public Block getChest() {
         return this.chest;
     }
 

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerTransactionListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerTransactionListener.java
@@ -1,4 +1,5 @@
 package me.deadlight.ezchestshop.Listeners;
+import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.Utils.Objects.TransactionLogObject;
 import me.deadlight.ezchestshop.Utils.Utils;
@@ -90,6 +91,7 @@ public class PlayerTransactionListener implements Listener {
 
         data.set(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING, finalString.toString());
         event.getChest().update();
+        ShopContainer.getShopSettings(event.getChest().getLocation()).setTrans(finalString.toString());
 
     }
 

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerTransactionListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerTransactionListener.java
@@ -5,6 +5,8 @@ import me.deadlight.ezchestshop.Utils.Objects.TransactionLogObject;
 import me.deadlight.ezchestshop.Utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
+import org.bukkit.block.TileState;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -22,7 +24,7 @@ public class PlayerTransactionListener implements Listener {
     @EventHandler
     public void onTransaction(PlayerTransactEvent event) {
         log(event);
-        if (event.getChest().getPersistentDataContainer().get(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER) == 1) {
+        if (((TileState)event.getChest().getState()).getPersistentDataContainer().get(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER) == 1) {
 
             List<UUID> getters = event.getAdminsUUID();
             getters.add(event.getOwner().getUniqueId());
@@ -58,8 +60,9 @@ public class PlayerTransactionListener implements Listener {
 
     private void log(PlayerTransactEvent event) {
 
-        PersistentDataContainer data = event.getChest().getPersistentDataContainer();
-        //player name@but|sell@price@time@count#
+        TileState state = ((TileState)event.getChest().getState());
+        PersistentDataContainer data = state.getPersistentDataContainer();
+        //player name@buy|sell@price@time@count#
 
         String ttype;
         if (event.isBuy()) {
@@ -90,7 +93,7 @@ public class PlayerTransactionListener implements Listener {
         }
 
         data.set(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING, finalString.toString());
-        event.getChest().update();
+        state.update();
         ShopContainer.getShopSettings(event.getChest().getLocation()).setTrans(finalString.toString());
 
     }

--- a/src/main/java/me/deadlight/ezchestshop/Utils/Objects/ChatWaitObject.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/Objects/ChatWaitObject.java
@@ -1,18 +1,42 @@
 package me.deadlight.ezchestshop.Utils.Objects;
-import org.bukkit.block.Chest;
+import me.deadlight.ezchestshop.Utils.Utils;
+import org.bukkit.Material;
+import org.bukkit.block.*;
+import org.bukkit.persistence.PersistentDataContainer;
 
 public class ChatWaitObject {
 
     public String answer;
     public String type;
-    public Chest rightChest;
+    public Block chest;
+    public PersistentDataContainer dataContainer;
 
-    public ChatWaitObject(String answer, String type, Chest rightchest) {
+    public ChatWaitObject(String answer, String type, Block chest) {
 
         this.answer = answer;
         this.type = type;
-        this.rightChest = rightchest;
+        this.chest = chest;
+        this.dataContainer = getDataContainer(chest.getState(), chest.getType());
 
     }
 
+    public ChatWaitObject(String answer, String type, Block chest, PersistentDataContainer dataContainer) {
+
+        this.answer = answer;
+        this.type = type;
+        this.chest = chest;
+        this.dataContainer = dataContainer;
+
+    }
+
+    private PersistentDataContainer getDataContainer(BlockState state, Material type) {
+        if (type == Material.CHEST) {
+            return ((Chest) state).getPersistentDataContainer();
+        } else if (type == Material.BARREL) {
+            return ((Barrel) state).getPersistentDataContainer();
+        } else if (Utils.isShulkerBox(type)) {
+            return ((ShulkerBox) state).getPersistentDataContainer();
+        }
+        return null;
+    }
 }

--- a/src/main/java/me/deadlight/ezchestshop/Utils/Objects/ShopSettings.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/Objects/ShopSettings.java
@@ -1,0 +1,105 @@
+package me.deadlight.ezchestshop.Utils.Objects;
+
+import me.deadlight.ezchestshop.Data.SQLite.Database;
+import me.deadlight.ezchestshop.EzChestShop;
+
+public class ShopSettings {
+
+    private String sloc;
+    private boolean msgtoggle;
+    private boolean dbuy;
+    private boolean dsell;
+    private String admins;
+    private boolean shareincome;
+    private String trans;
+    private boolean adminshop;
+
+    public ShopSettings(String sloc, boolean msgtoggle, boolean dbuy, boolean dsell, String admins, boolean shareincome,
+                        String trans, boolean adminshop) {
+        this.sloc = sloc;
+        this.msgtoggle = msgtoggle;
+        this.dbuy = dbuy;
+        this.dsell = dsell;
+        this.admins = admins;
+        this.shareincome = shareincome;
+        this.trans = trans;
+        this.adminshop = adminshop;
+    }
+
+    public boolean isMsgtoggle() {
+        return msgtoggle;
+    }
+
+    public void setMsgtoggle(boolean msgtoggle) {
+        this.msgtoggle = msgtoggle;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setBool("location", sloc,
+                "msgToggle", "shopdata", msgtoggle);
+    }
+
+    public boolean isDbuy() {
+        return dbuy;
+    }
+
+    public void setDbuy(boolean dbuy) {
+        this.dbuy = dbuy;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setBool("location", sloc,
+                "buyDisabled", "shopdata", dbuy);
+    }
+
+    public boolean isDsell() {
+        return dsell;
+    }
+
+    public void setDsell(boolean dsell) {
+        this.dsell = dsell;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setBool("location", sloc,
+                "sellDisabled", "shopdata", dsell);
+    }
+
+    public String getAdmins() {
+        return admins;
+    }
+
+    public void setAdmins(String admins) {
+        this.admins = admins;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setString("location", sloc,
+                "admins", "shopdata", admins);
+    }
+
+    public boolean isShareincome() {
+        return shareincome;
+    }
+
+    public void setShareincome(boolean shareincome) {
+        this.shareincome = shareincome;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setBool("location", sloc,
+                "shareIncome", "shopdata", shareincome);
+    }
+
+    public String getTrans() {
+        return trans;
+    }
+
+    public void setTrans(String trans) {
+        this.trans = trans;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setString("location", sloc,
+                "transactions", "shopdata", trans);
+    }
+
+    public boolean isAdminshop() {
+        return adminshop;
+    }
+
+    public void setAdminshop(boolean adminshop) {
+        this.adminshop = adminshop;
+        Database db = EzChestShop.getPlugin().getDatabase();
+        db.setBool("location", sloc,
+                "adminshop", "shopdata", adminshop);
+    }
+}

--- a/src/main/java/me/deadlight/ezchestshop/Utils/Utils.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/Utils.java
@@ -10,10 +10,11 @@ import me.deadlight.ezchestshop.Listeners.ChatListener;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
-import org.bukkit.block.Block;
-import org.bukkit.block.Chest;
+import org.bukkit.block.*;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.DoubleChestInventory;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.permissions.Permissible;
 import org.bukkit.permissions.PermissionAttachmentInfo;
@@ -89,6 +90,63 @@ public class Utils {
 
     }
 
+    /**
+     * Get the Inventory of the given Block if it is a Chest, Barrel or any Shulker
+     * @param block
+     * @return
+     */
+    public static Inventory getBlockInventory(Block block) {
+        if (block.getType() == Material.CHEST) {
+            return  ((Chest) block.getState()).getInventory();
+        } else if (block.getType() == Material.BARREL) {
+            return  ((Barrel) block.getState()).getInventory();
+        }
+        else if (isShulkerBox(block)) {
+            return  ((ShulkerBox) block.getState()).getInventory();
+        }
+        else return null;
+    }
+    /**
+     * Check if the given Block is a Shulker box (dye check)
+     * @param block
+     * @return
+     */
+    public static boolean isShulkerBox(Block block) {
+        return isShulkerBox(block.getType());
+    }
+
+    /**
+     * Check if the given Material is a Shulker box (dye check)
+     * @param type
+     * @return
+     */
+    public static boolean isShulkerBox(Material type) {
+        return Arrays.asList(Material.SHULKER_BOX, Material.WHITE_SHULKER_BOX, Material.ORANGE_SHULKER_BOX,
+                Material.MAGENTA_SHULKER_BOX, Material.LIGHT_BLUE_SHULKER_BOX, Material.YELLOW_SHULKER_BOX,
+                Material.LIME_SHULKER_BOX, Material.PINK_SHULKER_BOX, Material.GRAY_SHULKER_BOX,
+                Material.LIGHT_GRAY_SHULKER_BOX, Material.CYAN_SHULKER_BOX, Material.PURPLE_SHULKER_BOX,
+                Material.BLACK_SHULKER_BOX, Material.BROWN_SHULKER_BOX, Material.GRAY_SHULKER_BOX,
+                Material.RED_SHULKER_BOX, Material.BLACK_SHULKER_BOX).contains(type);
+    }
+
+    /**
+     * Check if the given Block is a applicable Shop.
+     * @param block
+     * @return
+     */
+    public static boolean isApplicableContainer(Block block) {
+        return isApplicableContainer(block.getType());
+    }
+
+    /**
+     * Check if the given Material is a applicable Shop.
+     * @param type
+     * @return
+     */
+    public static boolean isApplicableContainer(Material type) {
+        return (type == Material.CHEST && Config.container_chests) || (type == Material.BARREL && Config.container_barrels) || (isShulkerBox(type) && Config.container_shulkers);
+    }
+
 
     public static void reloadLanguages() {
         FileConfiguration fc = YamlConfiguration.loadConfiguration(new File(EzChestShop.getPlugin().getDataFolder(), "languages.yml"));
@@ -137,6 +195,10 @@ public class Utils {
 
             //new economy config section
             fc.set("economy.server-currency", "$");
+
+            fc.set("container.chests", true);
+            fc.set("container.barrels", true);
+            fc.set("container.shulkers", true);
             fc.save(new File(EzChestShop.getPlugin().getDataFolder(), "config.yml"));
             Config.loadConfig();
 

--- a/src/main/java/me/deadlight/ezchestshop/Utils/Utils.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/Utils.java
@@ -38,6 +38,15 @@ public class Utils {
 
     public static void storeItem(ItemStack item, PersistentDataContainer data) throws IOException {
 
+        String encodedItem = encodeItem(item);
+        if (encodedItem != null) {
+            data.set(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING, encodedItem);
+        }
+
+
+    }
+
+    public static String encodeItem(ItemStack item) {
         try {
             ByteArrayOutputStream io = new ByteArrayOutputStream();
             BukkitObjectOutputStream os = new BukkitObjectOutputStream(io);
@@ -49,14 +58,13 @@ public class Utils {
 
             String encodedData = Base64.getEncoder().encodeToString(rawData);
 
-            data.set(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING, encodedData);
             os.close();
+           return encodedData;
 
         } catch (IOException ex) {
             System.out.println(ex);
+            return null;
         }
-
-
     }
 
     public static ItemStack getItem(String encodedItem) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,6 +16,11 @@ hologram:
     toggled: false
     #Defines the range at which shops will render holograms (default: 10.0)
     range: 10.0
+#Define which containers are applicable for chest shops:
+container:
+  chests: true
+  barrels: true
+  shulkers: true
 economy:
   #Used to replace %currency% for the language files and the 2nd hologram line.
   server-currency: $


### PR DESCRIPTION
- Switched many mentions of the Chest class to Block in order to allow for multiple Container support.
- Added Utils method to get the inventory from a Block
- Added Utils method to check if a block or material is a Shulkerbox of any dye
- Added Utils method to check if a block or material is applicable as a Shop (Chest, barrel or Shulker) and if this Block is allowed as Shop, as defined in the config.yml
- The ChatListener class required some extra setup with the ChatWaitObject because it is called Async and .getState() throws an Error if it is not called on the main thread.
- Added Shulkerbox shop pickup and shop replace support. Pop up shops wohoo!
 - Current bug with the System is that pistons breaking the block or dispensers placing the shulker, will remove the shop. This also leaves the shop still stored in the database when broken by a piston.
- Another current bug is that Holograms appear with a dark Font on Barrels - Dead_Light is working on the fix.
- Fixed some minor issues from the Database branch like e.g. some left over debug outputs