### PR TITLE
Updated Piston Integration

### DIFF
--- a/src/main/java/me/deadlight/ezchestshop/Data/ShopContainer.java
+++ b/src/main/java/me/deadlight/ezchestshop/Data/ShopContainer.java
@@ -136,6 +136,33 @@ public class ShopContainer {
         shops.add(loc);
     }
 
+    public static PersistentDataContainer copyContainerData(PersistentDataContainer oldContainer, PersistentDataContainer newContainer) {
+        newContainer.set(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING,
+                oldContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING));
+        newContainer.set(new NamespacedKey(EzChestShop.getPlugin(), "buy"), PersistentDataType.DOUBLE,
+                oldContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "buy"), PersistentDataType.DOUBLE));
+        newContainer.set(new NamespacedKey(EzChestShop.getPlugin(), "sell"), PersistentDataType.DOUBLE,
+                oldContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "sell"), PersistentDataType.DOUBLE));
+        //add new settings data later
+        newContainer.set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER,
+                oldContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER));
+        newContainer.set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER,
+                oldContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER));
+        newContainer.set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER,
+                oldContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER));
+        newContainer.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING,
+                oldContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING));
+        newContainer.set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER,
+                oldContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER));
+        newContainer.set(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING,
+                oldContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING));
+        newContainer.set(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER,
+                oldContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER));
+        newContainer.set(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING,
+                oldContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING));
+        return newContainer;
+    }
+
     /**
      * Query the Database to retrieve all Shops a player owns.
      *

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/BlockBreakListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/BlockBreakListener.java
@@ -59,29 +59,7 @@ public class BlockBreakListener implements Listener {
                         PersistentDataContainer container = meta.getPersistentDataContainer();
                         PersistentDataContainer bcontainer = ((TileState) event.getBlock().getState()).getPersistentDataContainer();
                         if (bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) != null) {
-                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING,
-                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING));
-                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "buy"), PersistentDataType.DOUBLE,
-                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "buy"), PersistentDataType.DOUBLE));
-                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "sell"), PersistentDataType.DOUBLE,
-                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "sell"), PersistentDataType.DOUBLE));
-                            //add new settings data later
-                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER,
-                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER));
-                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER,
-                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER));
-                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER,
-                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER));
-                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING,
-                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING));
-                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER,
-                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER));
-                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING,
-                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING));
-                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER,
-                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER));
-                            container.set(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING,
-                                    bcontainer.get(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING));
+                            container = ShopContainer.copyContainerData(bcontainer, container);
                             shulker.setItemMeta(meta);
                             loc.getWorld().dropItemNaturally(loc, shulker);
                         }

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/BlockPistonExtendListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/BlockPistonExtendListener.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.inventory.InventoryPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -26,6 +27,8 @@ public class BlockPistonExtendListener implements Listener {
 
     private static HashMap<String, String> lockMap = new HashMap<>();
     private static List<String> lockList = new ArrayList<>();
+    private static HashMap<String, PersistentDataContainer> lockContainerMap = new HashMap<>();
+    private static HashMap<String, Location> lockLocationMap = new HashMap<>();
 
     @EventHandler
     public void onExtend(BlockPistonExtendEvent event) {
@@ -45,6 +48,8 @@ public class BlockPistonExtendListener implements Listener {
                         UUID uuid = UUID.randomUUID();
                         lockMap.put(uuid.toString(), ((ShulkerBox) state).getLock());
                         lockList.add(uuid.toString());
+                        lockContainerMap.put(uuid.toString(), container);
+                        lockLocationMap.put(uuid.toString(), shulkerLoc);
                         ((ShulkerBox) state).setLock(uuid.toString());
                         state.update();
 
@@ -71,6 +76,8 @@ public class BlockPistonExtendListener implements Listener {
                                             itemStack.setItemMeta(bsm);
                                             lockList.remove(lock);
                                             lockMap.remove(lock);
+                                            lockContainerMap.remove(lock);
+                                            lockLocationMap.remove(lock);
 
                                             //copy the new data over
                                             ItemMeta meta = itemStack.getItemMeta();
@@ -93,6 +100,47 @@ public class BlockPistonExtendListener implements Listener {
                         }, 5);
                     }
                 }
+            }
+        }
+    }
+
+    @EventHandler
+    public void InventoryItemPickup(InventoryPickupItemEvent event) {
+        Item item = event.getItem();
+        ItemStack itemStack = item.getItemStack();
+        if (Utils.isShulkerBox(itemStack.getType())) {
+            //get the lock
+            BlockStateMeta bsm = (BlockStateMeta) itemStack.getItemMeta();
+            ShulkerBox box = (ShulkerBox) bsm.getBlockState();
+            String lock = box.getLock();
+            //good, now validate that its the same shulker box that it was before
+            if (lock != null && lockList.contains(lock)) {
+                //it is surely that shulker
+
+                PersistentDataContainer container = lockContainerMap.get(lock);
+                Location shulkerLoc = lockLocationMap.get(lock);
+                //reset the lock
+                box.setLock(lockMap.get(lock));
+                box.update();
+                bsm.setBlockState(box);
+                itemStack.setItemMeta(bsm);
+                lockList.remove(lock);
+                lockMap.remove(lock);
+                lockContainerMap.remove(lock);
+                lockLocationMap.remove(lock);
+
+                //copy the new data over
+                ItemMeta meta = itemStack.getItemMeta();
+                PersistentDataContainer metaContainer = meta.getPersistentDataContainer();
+                metaContainer = ShopContainer.copyContainerData(container, metaContainer);
+                itemStack.setItemMeta(meta);
+
+                //Call the Event
+                item.setItemStack(itemStack);
+                ShulkerShopDropEvent shopDropEvent = new ShulkerShopDropEvent(item, shulkerLoc);
+                //idk if item also needs update after removing a persistent value (Have to check later) ^^^^
+                Bukkit.getPluginManager().callEvent(shopDropEvent);
+
             }
         }
     }

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/BlockPlaceListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/BlockPlaceListener.java
@@ -4,9 +4,12 @@ import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.Utils.Utils;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
+import org.bukkit.block.Dispenser;
 import org.bukkit.block.TileState;
+import org.bukkit.block.data.Directional;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockDispenseEvent;
@@ -20,43 +23,32 @@ public class BlockPlaceListener implements Listener {
 
     @EventHandler
     public void onBlockPlace(BlockPlaceEvent event) {
-
         Block block = event.getBlock();
         ItemStack item = event.getItemInHand();
         placeBlock(block, item);
+    }
+
+    @EventHandler
+    public void onBlockDispenserPlace(BlockDispenseEvent  event) {
+        Dispenser dispenser = ((Dispenser) event.getBlock().getState());
+        final Directional directional = (Directional) dispenser.getBlockData();
+        Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(), () -> {
+            Block block = event.getBlock().getRelative(directional.getFacing());
+            ItemStack item = event.getItem();
+            placeBlock(block, item);
+        }, 5);
 
     }
 
     private void placeBlock(Block block, ItemStack shulker) {
-        if (Utils.isShulkerBox(shulker.getType())) {
+        if (Utils.isShulkerBox(shulker.getType()) && Utils.isShulkerBox(block)) {
             if (shulker.hasItemMeta()) {
                 ItemMeta meta = shulker.getItemMeta();
                 PersistentDataContainer container = meta.getPersistentDataContainer();
                 if (container.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) != null) {
                     TileState state = ((TileState) block.getState());
                     PersistentDataContainer bcontainer = state.getPersistentDataContainer();
-                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING,
-                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING));
-                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "buy"), PersistentDataType.DOUBLE,
-                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "buy"), PersistentDataType.DOUBLE));
-                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "sell"), PersistentDataType.DOUBLE,
-                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "sell"), PersistentDataType.DOUBLE));
-                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER,
-                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER));
-                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER,
-                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER));
-                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER,
-                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER));
-                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING,
-                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING));
-                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER,
-                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER));
-                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING,
-                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "trans"), PersistentDataType.STRING));
-                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER,
-                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER));
-                    bcontainer.set(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING,
-                            container.get(new NamespacedKey(EzChestShop.getPlugin(), "item"), PersistentDataType.STRING));
+                    bcontainer = ShopContainer.copyContainerData(container, bcontainer);
                     state.update();
                     ShopContainer.loadShop(block.getLocation(), bcontainer);
                 }

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
@@ -116,11 +116,11 @@ public class PlayerCloseToChestListener implements Listener {
     private void showHologram(Location spawnLocation, Location shopLocation, ItemStack thatItem, double buy,
                               double sell, Player player) {
 
-        Location secondLineLocation = spawnLocation.clone().add(0, 0.3, 0).subtract(0, 1, 0);
+        Location secondLineLocation = spawnLocation.clone().add(0, 1.3, 0).subtract(0, 1, 0);
 
         Location thirdLocation = secondLineLocation.clone().subtract(0, 0.4, 0);
 
-        Location floatingItemLocation = thirdLocation.clone().add(0, 2, 0);
+        Location floatingItemLocation = thirdLocation.clone().add(0, 1, 0);
 
         String itemname = "Error";
 

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerLookingAtChestShop.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerLookingAtChestShop.java
@@ -100,11 +100,11 @@ public class PlayerLookingAtChestShop implements Listener {
 
         playershopmap.put(spawnLocation, player.getName());
 
-        Location secondLineLocation = spawnLocation.clone().add(0, 0.3, 0).subtract(0, 1, 0);
+        Location secondLineLocation = spawnLocation.clone().add(0, 1.3, 0).subtract(0, 1, 0);
 
         Location thirdLocation = secondLineLocation.clone().subtract(0, 0.4, 0);
 
-        Location floatingItemLocation = thirdLocation.clone().add(0, 2, 0);
+        Location floatingItemLocation = thirdLocation.clone().add(0, 1, 0);
 
         String itemname = "Error";
 

--- a/src/main/java/me/deadlight/ezchestshop/Utils/FloatingItem.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/FloatingItem.java
@@ -69,7 +69,7 @@ public class FloatingItem {
         PacketContainer destroyEntityPacket = new PacketContainer(PacketType.Play.Server.ENTITY_DESTROY);
         if (Utils.is1_17) {
             destroyEntityPacket.getIntegers().writeSafely(0, entityID);
-        }else if (Utils.is1_17_1) {
+        } else if (Utils.is1_17_1) {
             PlayEntityDestory_1_17_1.destroy(player, entityID);
         } else {
             destroyEntityPacket.getIntegers().writeSafely(0, 1);


### PR DESCRIPTION
- Added Loop to ensure the plugin works with multiple shulkers being broken by a single piston
- Switched Persistent Data check to Lock check because Persistent Data is not so persistent when it comes to Items dropping :P
- Created method to copy persistent data from one container to another to avoid code duplication
- Fixed incorrect cast of entityList to item.
- Added Hologram & Database removal