### PR TITLE
Command settings | copypasta!

### DIFF
--- a/src/main/java/me/deadlight/ezchestshop/Commands/MainCommands.java
+++ b/src/main/java/me/deadlight/ezchestshop/Commands/MainCommands.java
@@ -1,15 +1,23 @@
 package me.deadlight.ezchestshop.Commands;
 import com.bgsoftware.wildchests.api.handlers.ChestsManager;
+import me.deadlight.ezchestshop.Data.SQLite.Database;
 import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.Data.LanguageManager;
+import me.deadlight.ezchestshop.GUIs.SettingsGUI;
+import me.deadlight.ezchestshop.Utils.Objects.ShopSettings;
 import me.deadlight.ezchestshop.Utils.Utils;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.hover.content.Text;
 import org.bukkit.*;
 import org.bukkit.block.*;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.DoubleChestInventory;
@@ -20,10 +28,8 @@ import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.util.StringUtil;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class MainCommands implements CommandExecutor, TabCompleter {
 
@@ -31,6 +37,8 @@ public class MainCommands implements CommandExecutor, TabCompleter {
 
 
     public static LanguageManager lm = new LanguageManager();
+    public static HashMap<UUID, ShopSettings> settingsHashMap = new HashMap<>();
+    private enum SettingType {TOGGLE_MSG, DBUY, DSELL, ADMINS, SHAREINCOME};
 
     public static void updateLM(LanguageManager languageManager) {
         MainCommands.lm = languageManager;
@@ -65,7 +73,7 @@ public class MainCommands implements CommandExecutor, TabCompleter {
                                         e.printStackTrace();
                                     }
                                 } else {
-                                    player.sendMessage("Max-Shop limit reached: " + maxShops);
+                                    player.sendMessage(lm.maxShopLimitReached(maxShops));
                                 }
                             } else {
                                 player.sendMessage(lm.negativePrice());
@@ -79,6 +87,10 @@ public class MainCommands implements CommandExecutor, TabCompleter {
                 } else if (mainarg.equalsIgnoreCase("remove")) {
                         removeShop(player ,args);
 
+
+                } else if (mainarg.equalsIgnoreCase("settings")) {
+
+                    changeSettings(player, args);
 
                 } else {
                     sendHelp(player);
@@ -100,17 +112,91 @@ public class MainCommands implements CommandExecutor, TabCompleter {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
         List<String> fList = new ArrayList<String>();
-        List<String> list_mainarg = Arrays.asList("create", "remove");
+        List<String> list_mainarg = Arrays.asList("create", "remove", "settings");
         List<String> list_create_1 = Arrays.asList("[BuyPrice]");
         List<String> list_create_2 = Arrays.asList("[SellPrice]");
+        List<String> list_settings_1 = Arrays.asList("copy", "paste", "toggle-message", "toggle-buying", "toggle-selling", "admins", "toggle-shared-income");
+        List<String> list_settings_2 = Arrays.asList("add", "remove", "list", "clear");
         if (sender instanceof Player) {
+            Player player = (Player) sender;
             if (args.length == 1)
                 StringUtil.copyPartialMatches(args[0], list_mainarg, fList);
-            if (args.length > 1 && args[0].equalsIgnoreCase("create")) {
-                if (args.length == 2)
-                    StringUtil.copyPartialMatches(args[1], list_create_1, fList);
-                if (args.length == 3)
-                    StringUtil.copyPartialMatches(args[2], list_create_2, fList);
+            if (args.length > 1) {
+                if (args[0].equalsIgnoreCase("create")) {
+                    if (args.length == 2)
+                        StringUtil.copyPartialMatches(args[1], list_create_1, fList);
+                    if (args.length == 3)
+                        StringUtil.copyPartialMatches(args[2], list_create_2, fList);
+                } else if (args[0].equalsIgnoreCase("settings")) {
+                    if (args.length == 2)
+                        StringUtil.copyPartialMatches(args[1], list_settings_1, fList);
+                    if (args[1].equalsIgnoreCase("admins")) {
+                        if (args.length > 2) {
+                            if (args.length == 3) {
+                                StringUtil.copyPartialMatches(args[2], list_settings_2, fList);
+                            }
+                            BlockState blockState = getLookedAtBlockStateIfOwner(player, false, false);
+                            if (blockState != null) {
+                                if (args[2].equalsIgnoreCase("add")) {
+                                    if (args.length == 4) {
+                                        String adminString = ShopContainer
+                                                .getShopSettings(blockState.getLocation()).getAdmins();
+                                        if (adminString != null && !adminString.equalsIgnoreCase("none")) {
+                                            List<String> adminList = Arrays.asList(adminString
+                                                    .split("@")).stream().filter(s -> (s != null && !s.trim().equalsIgnoreCase(""))).map(s ->
+                                                    Bukkit.getOfflinePlayer(UUID.fromString(s)).getName())
+                                                    .collect(Collectors.toList());
+                                            String[] last = args[3].split(",");
+                                            List<String> online = Bukkit.getOnlinePlayers().stream().filter(p -> !player.getUniqueId().equals(p.getUniqueId())).map(HumanEntity::getName).collect(Collectors.toList());
+                                            online.removeAll(Arrays.asList(last));
+                                            online.removeAll(adminList);
+
+                                            if (args[3].endsWith(",")) {
+                                                for (String s : online) {
+                                                    fList.add(Arrays.asList(last).stream().collect(Collectors.joining(",")) + "," + s);
+                                                }
+                                            } else {
+                                                String lastarg = last[last.length -1];
+                                                for (String s : online) {
+                                                    if (s.startsWith(lastarg)) {
+                                                        last[last.length -1] = s;
+                                                        fList.add(Arrays.asList(last).stream().collect(Collectors.joining(",")));
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                } else if (args[2].equalsIgnoreCase("remove")) {
+                                    if (args.length == 4) {
+                                        String[] last = args[3].split(",");
+                                        String adminString = ShopContainer
+                                                .getShopSettings(blockState.getLocation()).getAdmins();
+                                        if (adminString != null && !adminString.equalsIgnoreCase("none")) {
+                                            List<String> playerList = Arrays.asList(adminString
+                                                    .split("@")).stream().filter(s -> (s != null && !s.trim().equalsIgnoreCase(""))).map(s ->
+                                                    Bukkit.getOfflinePlayer(UUID.fromString(s)).getName())
+                                                    .collect(Collectors.toList());
+                                            playerList.removeAll(Arrays.asList(last));
+                                            if (args[3].endsWith(",")) {
+                                                for (String s : playerList) {
+                                                    fList.add(Arrays.asList(last).stream().collect(Collectors.joining(",")) + "," + s);
+                                                }
+                                            } else {
+                                                String lastarg = last[last.length -1];
+                                                for (String s : playerList) {
+                                                    if (s.startsWith(lastarg)) {
+                                                        last[last.length -1] = s;
+                                                        fList.add(Arrays.asList(last).stream().collect(Collectors.joining(",")));
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
         return fList;
@@ -227,104 +313,291 @@ public class MainCommands implements CommandExecutor, TabCompleter {
 
     }
     private void removeShop(Player player, String[] args) {
-
-
-        Block block = player.getTargetBlockExact(6);
-
-        if (block != null && block.getType() != Material.AIR) {
-
-            BlockState blockState = block.getState();
-            if (blockState instanceof TileState) {
-
-                if (Utils.isApplicableContainer(block)) {
-
-                    if (checkIfLocation(block.getLocation(), player)) {
-
-
-                    TileState state = (TileState) blockState;
-
-                    PersistentDataContainer container = ((TileState) blockState).getPersistentDataContainer();
-                    Chest chkIfDCS = ifItsADoubleChestShop(block);
-
-                    if (container.has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || chkIfDCS != null) {
-
-                        if (chkIfDCS != null) {
-                            BlockState newBlockState = chkIfDCS.getBlock().getState();
-                            container = ((TileState) newBlockState).getPersistentDataContainer();
-                            state = (TileState) newBlockState;
-                        }
-
-
-                        String owner = Bukkit.getOfflinePlayer(UUID.fromString(container.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING))).getName();
-
-                        if (player.getName().equalsIgnoreCase(owner)) {
-                            //is the owner remove it
-
-                            container.remove(new NamespacedKey(EzChestShop.getPlugin(), "owner"));
-                            container.remove(new NamespacedKey(EzChestShop.getPlugin(), "buy"));
-                            container.remove(new NamespacedKey(EzChestShop.getPlugin(), "sell"));
-                            container.remove(new NamespacedKey(EzChestShop.getPlugin(), "item"));
-                            //add new settings data later
-                            try {
-
-                                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"));
-                                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"));
-                                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "dsell"));
-                                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "admins"));
-                                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"));
-                                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "trans"));
-                                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"));
-                                //msgtoggle 0/1
-                                //dbuy 0/1
-                                //dsell 0/1
-                                //admins [list of uuids seperated with @ in string form]
-                                //shareincome 0/1
-                                //logs [list of infos seperated by @ in string form]
-                                //trans [list of infos seperated by @ in string form]
-                                //adminshop 0/1
-                            }catch (Exception ex) {
-                                //nothing really worrying...
-                            }
-
-                            ShopContainer.deleteShop(block.getLocation());
-
-
-                            state.update();
-                            player.sendMessage(lm.chestShopRemoved());
-
-                        } else {
-
-                            player.sendMessage(lm.notOwner());
-
-                        }
-
-
-                    } else {
-
-                        player.sendMessage(lm.notAChestOrChestShop());
-
-                    }
-                } else {
-                        player.sendMessage(lm.notAllowedToCreateOrRemove());
-                    }
-                } else {
-                    player.sendMessage(lm.notAChestOrChestShop());
-                }
-
-            } else {
-
-                player.sendMessage(lm.notAChestOrChestShop());
+        BlockState blockState = getLookedAtBlockStateIfOwner(player, true, true);
+        if (blockState != null) {
+            //is the owner remove it
+            PersistentDataContainer container = ((TileState) blockState).getPersistentDataContainer();
+            container.remove(new NamespacedKey(EzChestShop.getPlugin(), "owner"));
+            container.remove(new NamespacedKey(EzChestShop.getPlugin(), "buy"));
+            container.remove(new NamespacedKey(EzChestShop.getPlugin(), "sell"));
+            container.remove(new NamespacedKey(EzChestShop.getPlugin(), "item"));
+            //add new settings data later
+            try {
+                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"));
+                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"));
+                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "dsell"));
+                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "admins"));
+                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"));
+                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "trans"));
+                container.remove(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"));
+                //msgtoggle 0/1
+                //dbuy 0/1
+                //dsell 0/1
+                //admins [list of uuids seperated with @ in string form]
+                //shareincome 0/1
+                //logs [list of infos seperated by @ in string form]
+                //trans [list of infos seperated by @ in string form]
+                //adminshop 0/1
+            }catch (Exception ex) {
+                //nothing really worrying...
             }
 
+            ShopContainer.deleteShop(blockState.getLocation());
 
-        } else {
 
-            player.sendMessage(lm.notAChestOrChestShop());
+            blockState.update();
+            player.sendMessage(lm.chestShopRemoved());
+        }
+    }
+
+    private void changeSettings(Player player, String args[]) {
+        if (args.length == 1) {
+            BlockState blockState = getLookedAtBlockStateIfOwner(player, true, false);
+            if (blockState != null) {
+                SettingsGUI settingsGUI = new SettingsGUI();
+                settingsGUI.showGUI(player, blockState.getBlock(), false);
+                player.playSound(player.getLocation(), Sound.BLOCK_PISTON_EXTEND, 0.5f, 0.5f);
+            }
+        } else if (args.length >= 2) {
+
+            String settingarg = args[1];
+
+            if (settingarg.equalsIgnoreCase("copy")) {
+                copyShopSettings(player);
+            } else if (settingarg.equalsIgnoreCase("paste")) {
+                pasteShopSettings(player);
+            } else if (settingarg.equalsIgnoreCase("toggle-message")) {
+                modifyShopSettings(player, SettingType.TOGGLE_MSG, "");
+            } else if (settingarg.equalsIgnoreCase("toggle-buying")) {
+                modifyShopSettings(player, SettingType.DBUY, "");
+            } else if (settingarg.equalsIgnoreCase("toggle-selling")) {
+                modifyShopSettings(player, SettingType.DSELL, "");
+            } else if (settingarg.equalsIgnoreCase("toggle-shared-income")) {
+                modifyShopSettings(player, SettingType.SHAREINCOME, "");
+            }
+
+            if (settingarg.equalsIgnoreCase("admins")) {
+                if (args.length == 3) {
+                    if (args[2].equalsIgnoreCase("clear")) {
+                        modifyShopSettings(player, SettingType.ADMINS, "clear");
+                    } else if (args[2].equalsIgnoreCase("list")) {
+                        BlockState blockState = getLookedAtBlockStateIfOwner(player, true, false);
+                        if (blockState != null) {
+                            String adminString = ShopContainer.getShopSettings(
+                                    blockState.getLocation()).getAdmins();
+                            if (adminString != null && !adminString.equalsIgnoreCase("none")) {
+                                List<String> adminList = Arrays.asList(adminString.split("@"));
+                                if (adminList != null && !adminList.isEmpty()) {
+                                    player.sendMessage(ChatColor.GREEN + "Admins:\n" + ChatColor.GRAY + " - " + ChatColor.YELLOW + adminList.stream().map(s -> Bukkit.getOfflinePlayer(
+                                            UUID.fromString(s)).getName()).collect(
+                                            Collectors.joining("\n" + ChatColor.GRAY + " - " + ChatColor.YELLOW)));
+                                } else {
+                                    player.sendMessage(ChatColor.GREEN + "Admins:\n" + ChatColor.GRAY + " - " + ChatColor.YELLOW + lm.nobodyStatusAdmins());
+                                }
+                            }else {
+                                player.sendMessage(ChatColor.GREEN + "Admins:\n" + ChatColor.GRAY + " - " + ChatColor.YELLOW + lm.nobodyStatusAdmins());
+                            }
+                        }
+                    }
+                } else if (args.length == 4) {
+                    if (args[2].equalsIgnoreCase("add")) {
+                        modifyShopSettings(player, SettingType.ADMINS, "+" + args[3]);
+                    } else if (args[2].equalsIgnoreCase("remove")) {
+                        modifyShopSettings(player, SettingType.ADMINS, "-" + args[3]);
+                    }
+                }
+            }
+        }
+    }
+
+    private void copyShopSettings(Player player) {
+        BlockState blockState = getLookedAtBlockStateIfOwner(player, true, false);
+        if (blockState != null) {
+            ShopSettings settings = ShopContainer.getShopSettings(blockState.getLocation());
+            List<String> adminList = (settings.getAdmins() == null || settings.getAdmins().equalsIgnoreCase("none")) ? null : Arrays.asList(settings.getAdmins().split("@"));
+            String adminString;
+            if (adminList == null || adminList.isEmpty()) {
+                adminString = lm.nobodyStatusAdmins();
+            } else {
+                adminString = adminList.stream().map(id -> Bukkit.getOfflinePlayer(UUID.fromString(id)).getName()).collect(Collectors.joining(", "));
+            }
+            settingsHashMap.put(player.getUniqueId(), settings.clone());
+            player.spigot().sendMessage(new ComponentBuilder(lm.copiedShopSettings()).event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(
+                lm.toggleTransactionMessageButton() + ": "  + (settings.isMsgtoggle() ? lm.statusOn() : lm.statusOff()) + "\n" +
+                lm.disableBuyingButtonTitle() + ": "  + (settings.isDbuy() ? lm.statusOn() : lm.statusOff()) + "\n" +
+                lm.disableSellingButtonTitle() + ": "  + (settings.isDsell() ? lm.statusOn() : lm.statusOff()) + "\n" +
+                lm.shopAdminsButtonTitle() + ": " + net.md_5.bungee.api.ChatColor.GREEN + adminString + "\n" +
+                lm.shareIncomeButtonTitle() + ": "  + (settings.isShareincome() ? lm.statusOn() : lm.statusOff())
+            ))).create());
+        }
+    }
+
+    private void pasteShopSettings(Player player) {
+        BlockState blockState = getLookedAtBlockStateIfOwner(player, true, false);
+        if (blockState != null) {
+            // owner confirmed
+            PersistentDataContainer container = ((TileState) blockState).getPersistentDataContainer();
+            ShopSettings settings = settingsHashMap.get(player.getUniqueId());
+            Database db = EzChestShop.getPlugin().getDatabase();
+            String sloc = Utils.LocationtoString(blockState.getLocation());
+            String admins = settings.getAdmins() == null ? "none" : settings.getAdmins();
+            db.setBool("location", sloc,
+                    "msgToggle", "shopdata", settings.isMsgtoggle());
+            db.setBool("location", sloc,
+                    "buyDisabled", "shopdata", settings.isDbuy());
+            db.setBool("location", sloc,
+                    "sellDisabled", "shopdata", settings.isDbuy());
+            db.setString("location", sloc,
+                    "admins", "shopdata", admins);
+            db.setBool("location", sloc,
+                    "shareIncome", "shopdata", settings.isShareincome());
+            container.set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER,
+                    settings.isMsgtoggle() ? 1 : 0);
+            container.set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER,
+                    settings.isDbuy() ? 1 : 0);
+            container.set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER,
+                    settings.isDsell() ? 1 : 0);
+            container.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING,
+                    admins);
+            container.set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER,
+                    settings.isShareincome() ? 1 : 0);
+            ShopSettings newSettings = ShopContainer.getShopSettings(blockState.getLocation());
+            newSettings.setMsgtoggle(settings.isMsgtoggle());
+            newSettings.setDbuy(settings.isDbuy());
+            newSettings.setDsell(settings.isDsell());
+            newSettings.setAdmins(settings.getAdmins());
+            newSettings.setShareincome(settings.isShareincome());
+            blockState.update();
+            player.sendMessage(lm.pastedShopSettings());
 
         }
 
+    }
 
+    private void modifyShopSettings(Player player, SettingType type, String data) {
+        BlockState blockState = getLookedAtBlockStateIfOwner(player, true, false);
+        if (blockState != null) {
+            ShopSettings settings = ShopContainer.getShopSettings(blockState.getLocation());
+            Database db = EzChestShop.getPlugin().getDatabase();
+            String sloc = Utils.LocationtoString(blockState.getLocation());
+            PersistentDataContainer container = ((TileState) blockState).getPersistentDataContainer();
+            switch (type) {
+                case DBUY:
+                    settings.setDbuy(!settings.isDbuy());
+                    db.setBool("location", sloc,
+                            "buyDisabled", "shopdata", settings.isDbuy());
+                    container.set(new NamespacedKey(EzChestShop.getPlugin(), "dbuy"), PersistentDataType.INTEGER,
+                            settings.isDbuy() ? 1: 0);
+                    if (settings.isDbuy()) {
+                        player.sendMessage(lm.disableBuyingOnInChat());
+                    } else {
+                        player.sendMessage(lm.disableBuyingOffInChat());
+                    }
+                    break;
+                case DSELL:
+                    settings.setDsell(!settings.isDsell());
+                    db.setBool("location", sloc,
+                            "sellDisabled", "shopdata", settings.isDsell());
+                    container.set(new NamespacedKey(EzChestShop.getPlugin(), "dsell"), PersistentDataType.INTEGER,
+                            settings.isDsell() ? 1 : 0);
+                    if (settings.isDsell()) {
+                        player.sendMessage(lm.disableSellingOnInChat());
+                    } else {
+                        player.sendMessage(lm.disableSellingOffInChat());
+                    }
+                    break;
+                case ADMINS:
+                    if (data.equalsIgnoreCase("clear")) {
+                        data = null;
+                        player.sendMessage(lm.clearedAdmins());
+                    } else if (data.startsWith("+")) {
+                        data = data.replace("+", "");
+                        List<UUID> oldData = (settings.getAdmins() == null || settings.getAdmins().equals("none")) ? new ArrayList<>() :
+                                new ArrayList<>(Arrays.asList(settings.getAdmins().split("@")))
+                                        .stream().map(UUID::fromString).collect(Collectors.toList());
+                        List<UUID> newPlayers = Arrays.asList(data.split(",")).stream().map(p -> Bukkit.getOfflinePlayer(p))
+                                .filter(p -> p.hasPlayedBefore()).map(p -> p.getUniqueId()).filter(id -> !oldData.contains(id)).collect(Collectors.toList());
+                        String newData = newPlayers.stream().map(s -> s.toString()).collect(Collectors.joining("@"));
+                        if (newData != null && !newData.equalsIgnoreCase("")) {
+                            if (!newPlayers.contains(player.getUniqueId())) {
+                                if (settings.getAdmins() == null || settings.getAdmins().equalsIgnoreCase("")) {
+                                    data = newData;
+                                } else {
+                                    data = settings.getAdmins() + "@" + newData;
+                                }
+                                player.sendMessage(lm.sucAdminAdded(newPlayers.stream()
+                                        .map(s -> Bukkit.getOfflinePlayer(s).getName())
+                                        .collect(Collectors.joining(", "))));
+                            } else {
+                                data = settings.getAdmins();
+                                player.sendMessage(lm.selfAdmin());
+                            }
+                        } else {
+                            data = settings.getAdmins();
+                            player.sendMessage(lm.noPlayer());
+                        }
 
+                    } else if (data.startsWith("-")) {
+                        data = data.replace("-", "");
+                        List<String> oldData = (settings.getAdmins() == null || settings.getAdmins().equalsIgnoreCase("none"))
+                                ? new ArrayList<>() : new ArrayList<>(Arrays.asList(settings.getAdmins().split("@")));
+                        List<UUID> newPlayers= new ArrayList<>(Arrays.asList(data.split(",")).stream().map(p -> Bukkit.getOfflinePlayer(p))
+                                .filter(p -> p.hasPlayedBefore()).map(p -> p.getUniqueId()).collect(Collectors.toList()));
+                        if (newPlayers != null && !newPlayers.isEmpty()) {
+                            List<String> newData = newPlayers.stream().map(p -> p.toString()).collect(Collectors.toList());
+                            oldData.removeAll(newData);
+                            data = oldData.stream().collect(Collectors.joining("@"));
+                            player.sendMessage(lm.sucAdminRemoved(newPlayers.stream()
+                                    .map(s -> Bukkit.getOfflinePlayer(s).getName())
+                                    .collect(Collectors.joining(", "))));
+                            if (data.trim().equalsIgnoreCase("")) {
+                                data = null;
+                            }
+                        } else {
+                            data = settings.getAdmins();
+                            player.sendMessage(lm.noPlayer());
+                        }
+                    }
+                    if (data == null || data.equalsIgnoreCase("none")) {
+                        data = null;
+                    } else if (data.contains("none@")) {
+                        data = data.replace("none@", "");
+                    }
+                    settings.setAdmins(data);
+                    String admins = settings.getAdmins() == null ? "none" : settings.getAdmins();
+                    db.setString("location", sloc,
+                            "admins", "shopdata", admins);
+                    container.set(new NamespacedKey(EzChestShop.getPlugin(), "admins"), PersistentDataType.STRING,
+                            admins);
+                    break;
+                case TOGGLE_MSG:
+                    settings.setMsgtoggle(!settings.isMsgtoggle());
+                    db.setBool("location", sloc,
+                            "msgToggle", "shopdata", settings.isMsgtoggle());
+                    container.set(new NamespacedKey(EzChestShop.getPlugin(), "msgtoggle"), PersistentDataType.INTEGER,
+                            settings.isMsgtoggle() ? 1 : 0);
+                    if (settings.isMsgtoggle()) {
+                        player.sendMessage(lm.toggleTransactionMessageOnInChat());
+                    } else {
+                        player.sendMessage(lm.toggleTransactionMessageOffInChat());
+                    }
+                    break;
+                case SHAREINCOME:
+                    settings.setShareincome(!settings.isShareincome());
+                    db.setBool("location", sloc,
+                            "shareIncome", "shopdata", settings.isShareincome());
+                    container.set(new NamespacedKey(EzChestShop.getPlugin(), "shareincome"), PersistentDataType.INTEGER,
+                            settings.isShareincome() ? 1 : 0);
+                    if (settings.isShareincome()) {
+                        player.sendMessage(lm.sharedIncomeOnInChat());
+                    } else {
+                        player.sendMessage(lm.sharedIncomeOffInChat());
+                    }
+                    break;
+            }
+
+            blockState.update();
+        }
     }
 
 
@@ -401,6 +674,72 @@ public class MainCommands implements CommandExecutor, TabCompleter {
                     return rightone;
                 }
             }
+        }
+        return null;
+    }
+
+    private BlockState getLookedAtBlockStateIfOwner(Player player, boolean sendErrors, boolean isCreateOrRemove) {
+        Block block = player.getTargetBlockExact(6);
+        if (block != null && block.getType() != Material.AIR) {
+            BlockState blockState = block.getState();
+
+            if (blockState instanceof TileState) {
+
+                if (Utils.isApplicableContainer(block)) {
+
+                    if (checkIfLocation(block.getLocation(), player)) {
+
+                        if (block.getType() == Material.CHEST || block.getType() == Material.TRAPPED_CHEST) {
+                            Inventory inventory = Utils.getBlockInventory(block);
+                            if (Utils.getBlockInventory(block) instanceof DoubleChestInventory) {
+                                DoubleChest doubleChest = (DoubleChest) inventory.getHolder();
+                                Chest chestleft = (Chest) doubleChest.getLeftSide();
+                                Chest chestright = (Chest) doubleChest.getRightSide();
+
+                                if (!chestleft.getPersistentDataContainer().isEmpty()) {
+                                    blockState = chestleft.getBlock().getState();
+                                } else {
+                                    blockState = chestright.getBlock().getState();
+                                }
+                            }
+                        }
+
+                        PersistentDataContainer container = ((TileState) blockState).getPersistentDataContainer();
+                        Chest chkIfDCS = ifItsADoubleChestShop(block);
+
+                        if (container.has(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING) || chkIfDCS != null) {
+
+                            if (chkIfDCS != null) {
+                                BlockState newBlockState = chkIfDCS.getBlock().getState();
+                                container = ((TileState) newBlockState).getPersistentDataContainer();
+                            }
+
+
+                            String owner = Bukkit.getOfflinePlayer(UUID.fromString(container.get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING))).getName();
+
+                            if (player.getName().equalsIgnoreCase(owner)) {
+                                return blockState;
+                            } else if (sendErrors) {
+                                player.sendMessage(lm.notOwner());
+                            }
+                        } else if (sendErrors) {
+                            player.sendMessage(lm.notAChestOrChestShop());
+                        }
+                    } else if (sendErrors) {
+                        if (isCreateOrRemove) {
+                            player.sendMessage(lm.notAllowedToCreateOrRemove());
+                        } else {
+                            player.sendMessage(lm.notAChestOrChestShop());
+                        }
+                    }
+                } else if (sendErrors) {
+                    player.sendMessage(lm.notAChestOrChestShop());
+                }
+            } else if (sendErrors) {
+                player.sendMessage(lm.notAChestOrChestShop());
+            }
+        } else if (sendErrors) {
+            player.sendMessage(lm.notAChestOrChestShop());
         }
         return null;
     }

--- a/src/main/java/me/deadlight/ezchestshop/Data/LanguageManager.java
+++ b/src/main/java/me/deadlight/ezchestshop/Data/LanguageManager.java
@@ -1,8 +1,9 @@
 package me.deadlight.ezchestshop.Data;
-import me.deadlight.ezchestshop.Data.Config;
+
 import me.deadlight.ezchestshop.EzChestShop;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -396,6 +397,11 @@ public class LanguageManager {
         }
         return finalList;
     }
+
+    public String copiedShopSettings() { return colorify(languages.getString("copiedShopSettings")); }
+    public String pastedShopSettings() { return colorify(languages.getString("pastedShopSettings")); }
+    public String clearedAdmins() { return colorify(languages.getString("clearedAdmins")); }
+    public String maxShopLimitReached(int max) { return colorify(languages.getString("maxShopLimitReached")).replace("%shoplimit%", "" + max); }
 
 
 

--- a/src/main/java/me/deadlight/ezchestshop/Data/ShopContainer.java
+++ b/src/main/java/me/deadlight/ezchestshop/Data/ShopContainer.java
@@ -8,7 +8,6 @@ import me.deadlight.ezchestshop.Utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
-import org.bukkit.block.Chest;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
@@ -32,7 +32,7 @@ public class PlayerCloseToChestListener implements Listener {
 
     public static HashMap<Player, List<ASHologramObject>> map = new HashMap<>();
 
-    private static HashMap<Location, String> playershopmap = new HashMap<>();
+    private static HashMap<Location, List<Player>> playershopmap = new HashMap<>();
 
     @EventHandler
     public void onMove(PlayerMoveEvent event) {
@@ -46,7 +46,7 @@ public class PlayerCloseToChestListener implements Listener {
                     double dist = loc.distance(sloc);
             //Show the Hologram if Player close enough
             if (dist < Config.holodistancing_distance) {
-                if (isAlreadyPresenting(sloc, player.getName()))
+                if (isAlreadyPresenting(sloc, player))
                     return; //forEach -> acts as continue;
 
                     Block target = sloc.getWorld().getBlockAt(sloc);
@@ -75,7 +75,11 @@ public class PlayerCloseToChestListener implements Listener {
 
                             showHologram(holoLoc, sloc, thatItem, buy, sell, event.getPlayer());
                             //mark the shop as visible
-                            playershopmap.put(sloc, player.getName());
+                            List<Player> players = playershopmap.get(sloc);
+                            if (players == null)
+                                players = new ArrayList<>();
+                            players.add(player);
+                            playershopmap.put(sloc, players);
 
                         }
                     }
@@ -163,7 +167,10 @@ public class PlayerCloseToChestListener implements Listener {
                 holo.getFloatingItem().destroy();
                 Utils.onlinePackets.remove(holo.getFloatingItem());
 
-                playershopmap.remove(loc);
+                List<Player> players = playershopmap.get(loc);
+                players.remove(p);
+                if (players.isEmpty())
+                    playershopmap.remove(loc);
                 List<ASHologramObject> holoList = map.get(p);
                 holoList.remove(holo);
                 map.put(p, holoList);
@@ -171,11 +178,11 @@ public class PlayerCloseToChestListener implements Listener {
         }
     }
 
-    private boolean isAlreadyPresenting(Location location, String playername) {
+    private boolean isAlreadyPresenting(Location location, Player player) {
 
         if (playershopmap.containsKey(location)) {
 
-            if (playershopmap.get(location).equalsIgnoreCase(playername)) {
+            if (playershopmap.get(location).contains(player)) {
                 return true;
             } else {
                 return false;

--- a/src/main/java/me/deadlight/ezchestshop/Utils/Objects/ShopSettings.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/Objects/ShopSettings.java
@@ -26,80 +26,102 @@ public class ShopSettings {
         this.adminshop = adminshop;
     }
 
+    private ShopSettings(ShopSettings settings) {
+        this.sloc = settings.sloc;
+        this.msgtoggle = settings.msgtoggle;
+        this.dbuy = settings.dbuy;
+        this.dsell = settings.dsell;
+        this.admins = settings.admins;
+        this.shareincome = settings.shareincome;
+        this.trans = settings.trans;
+        this.adminshop = settings.adminshop;
+    }
+
+    public ShopSettings clone() {
+        return new ShopSettings(this);
+    }
+
     public boolean isMsgtoggle() {
         return msgtoggle;
     }
 
-    public void setMsgtoggle(boolean msgtoggle) {
+    public ShopSettings setMsgtoggle(boolean msgtoggle) {
         this.msgtoggle = msgtoggle;
         Database db = EzChestShop.getPlugin().getDatabase();
         db.setBool("location", sloc,
                 "msgToggle", "shopdata", msgtoggle);
+        return this;
     }
 
     public boolean isDbuy() {
         return dbuy;
     }
 
-    public void setDbuy(boolean dbuy) {
+    public ShopSettings setDbuy(boolean dbuy) {
         this.dbuy = dbuy;
         Database db = EzChestShop.getPlugin().getDatabase();
         db.setBool("location", sloc,
                 "buyDisabled", "shopdata", dbuy);
+        return this;
     }
 
     public boolean isDsell() {
         return dsell;
     }
 
-    public void setDsell(boolean dsell) {
+    public ShopSettings setDsell(boolean dsell) {
         this.dsell = dsell;
         Database db = EzChestShop.getPlugin().getDatabase();
         db.setBool("location", sloc,
                 "sellDisabled", "shopdata", dsell);
+        return this;
     }
 
     public String getAdmins() {
         return admins;
     }
 
-    public void setAdmins(String admins) {
+    public ShopSettings setAdmins(String admins) {
         this.admins = admins;
         Database db = EzChestShop.getPlugin().getDatabase();
         db.setString("location", sloc,
                 "admins", "shopdata", admins);
+        return this;
     }
 
     public boolean isShareincome() {
         return shareincome;
     }
 
-    public void setShareincome(boolean shareincome) {
+    public ShopSettings setShareincome(boolean shareincome) {
         this.shareincome = shareincome;
         Database db = EzChestShop.getPlugin().getDatabase();
         db.setBool("location", sloc,
                 "shareIncome", "shopdata", shareincome);
+        return this;
     }
 
     public String getTrans() {
         return trans;
     }
 
-    public void setTrans(String trans) {
+    public ShopSettings setTrans(String trans) {
         this.trans = trans;
         Database db = EzChestShop.getPlugin().getDatabase();
         db.setString("location", sloc,
                 "transactions", "shopdata", trans);
+        return this;
     }
 
     public boolean isAdminshop() {
         return adminshop;
     }
 
-    public void setAdminshop(boolean adminshop) {
+    public ShopSettings setAdminshop(boolean adminshop) {
         this.adminshop = adminshop;
         Database db = EzChestShop.getPlugin().getDatabase();
         db.setBool("location", sloc,
                 "adminshop", "shopdata", adminshop);
+        return this;
     }
 }

--- a/src/main/java/me/deadlight/ezchestshop/Utils/Utils.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/Utils.java
@@ -207,6 +207,7 @@ public class Utils {
         //update 1.2.8 Languages
         boolean result = YamlConfiguration.loadConfiguration(new File(EzChestShop.getPlugin().getDataFolder(), "languages.yml")).isString("commandmsg-negativeprice");
         boolean update1_3_0 = YamlConfiguration.loadConfiguration(new File(EzChestShop.getPlugin().getDataFolder(), "languages.yml")).isString("settingsButton");
+        boolean update1_4_0 = YamlConfiguration.loadConfiguration(new File(EzChestShop.getPlugin().getDataFolder(), "languages.yml")).isString("copiedShopSettings");
         if (!result) {
             FileConfiguration fc = YamlConfiguration.loadConfiguration(new File(EzChestShop.getPlugin().getDataFolder(), "languages.yml"));
             //new values that were added in update 1.2.8
@@ -281,6 +282,17 @@ public class Utils {
             fc.save(new File(EzChestShop.getPlugin().getDataFolder(), "languages.yml"));
             reloadLanguages();
             EzChestShop.getPlugin().logConsole("&c[&eEzChestShop&c]&r &bNew languages.yml generated... (1.3.0V)");
+        }
+        if (!update1_4_0) {
+            FileConfiguration fc = YamlConfiguration.loadConfiguration(new File(EzChestShop.getPlugin().getDataFolder(), "languages.yml"));
+            //for update 1.4.0
+            fc.set("copiedShopSettings", "&6Copied &7shop settings!");
+            fc.set("pastedShopSettings", "&ePasted &7shop settings!");
+            fc.set("clearedAdmins", "&cRemoved all admins from this shop.");
+            fc.set("maxShopLimitReached", "&cMaximum shop limit reached: %shoplimit%!");
+            fc.save(new File(EzChestShop.getPlugin().getDataFolder(), "languages.yml"));
+            reloadLanguages();
+            EzChestShop.getPlugin().logConsole("&c[&eEzChestShop&c]&r &bNew languages.yml generated... (1.4.0V)");
         }
     }
 

--- a/src/main/resources/languages.yml
+++ b/src/main/resources/languages.yml
@@ -90,4 +90,9 @@ sucAdminAdded: "&e%player% &asuccessfully added to the admins list."
 alreadyAdmin: "&cThis player is already in the admins list!"
 sucAdminRemoved: "&e%player% &asuccessfully removed from the admins list."
 notInAdminList: "&cThis player is not in the admins list!"
+#Update 1.4.0
+copiedShopSettings: "&6Copied &7shop settings!"
+pastedShopSettings: "&ePasted &7shop settings!"
+maxShopLimitReached: "&cMaximum shop limit reached: %shoplimit%!"
+clearedAdmins: "&cRemoved all admins from this shop."
 


### PR DESCRIPTION
- Added the possibility to modify a shop's settings using Commands.
 - All Settings options are supported + a few extra:
 - Added copy option. This will copy the current state of a shop (with representation in chat on Hover) and allows the user to paste it to another shop.
 - Added Option to add or remove multiple admins separated by commas ",". Added a more complex Tabcomplete Handler that does also work with multiple commas and only shows applicable users (that are online or part of the admin list already in the case of remove)
- Added required Extra languagle.yml lines as well as the language yml updater for 1.4.0
- fixed a bug with Holograms duplicating when using the distancing feature and multiple people would move. Might break with the other system too, though more unlikely as less Holograms are shown.