### PR TITLE
WorldGuard | Placeholders | Permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,10 @@
             <url>https://repo.codemc.org/repository/maven-public/</url>
             <layout>default</layout>
         </repository>
+        <repository>
+            <id>sk89q-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -189,6 +193,12 @@
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
             <version>2.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.5</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/me/deadlight/ezchestshop/EzChestShop.java
+++ b/src/main/java/me/deadlight/ezchestshop/EzChestShop.java
@@ -18,6 +18,7 @@ import me.deadlight.ezchestshop.Utils.CommandRegister;
 import me.deadlight.ezchestshop.Utils.FloatingItem;
 import me.deadlight.ezchestshop.Utils.Exceptions.CommandFetchException;
 import me.deadlight.ezchestshop.Utils.Utils;
+import me.deadlight.ezchestshop.Utils.WorldGuard.FlagRegistry;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.command.PluginCommand;
@@ -43,15 +44,25 @@ public final class EzChestShop extends JavaPlugin {
 
     public static boolean protocollib = false;
     public static boolean slimefun = false;
+    public static boolean worldguard = false;
 
     private static ProtocolManager manager;
 
 
     @Override
+    public void onLoad() {
+        // Adds Custom Flags to WorldGuard!
+        if (getServer().getPluginManager().getPlugin("WorldGuard") != null) {
+            worldguard = true;
+            FlagRegistry.onLoad();
+        }
+    }
+
+    @Override
     public void onEnable() {
 
         plugin = this;
-        logConsole("&c[&eEzChestShop&c] &aEnabling EzChestShop - version 1.4.3");
+        logConsole("&c[&eEzChestShop&c] &aEnabling EzChestShop - version " + this.getDescription().getVersion());
         saveDefaultConfig();
 
         this.db = new SQLite(this);

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/BlockPistonExtendListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/BlockPistonExtendListener.java
@@ -5,6 +5,8 @@ import me.deadlight.ezchestshop.Data.ShopContainer;
 import me.deadlight.ezchestshop.Events.ShulkerShopDropEvent;
 import me.deadlight.ezchestshop.EzChestShop;
 import me.deadlight.ezchestshop.Utils.Utils;
+import me.deadlight.ezchestshop.Utils.WorldGuard.FlagRegistry;
+import me.deadlight.ezchestshop.Utils.WorldGuard.WorldGuardUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -49,6 +51,20 @@ public class BlockPistonExtendListener implements Listener {
                     //it is a shulkerbox, now checking if its a shop
                     Location shulkerLoc = block.getLocation();
                     if (ShopContainer.isShop(shulkerLoc)) {
+                        boolean adminshop = container.get(new NamespacedKey(EzChestShop.getPlugin(), "adminshop"), PersistentDataType.INTEGER) == 1;
+                        if (EzChestShop.worldguard) {
+                            if (adminshop) {
+                                if (!WorldGuardUtils.queryStateFlag(FlagRegistry.REMOVE_ADMIN_SHOP, shulkerLoc)) {
+                                    event.setCancelled(true);
+                                    return;
+                                }
+                            } else {
+                                if (!WorldGuardUtils.queryStateFlag(FlagRegistry.REMOVE_SHOP, shulkerLoc)) {
+                                    event.setCancelled(true);
+                                    return;
+                                }
+                            }
+                        }
                         //congrats
                         //Add the Lock for dropped item recognition later
                         UUID uuid = UUID.randomUUID();

--- a/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
+++ b/src/main/java/me/deadlight/ezchestshop/Listeners/PlayerCloseToChestListener.java
@@ -247,6 +247,11 @@ public class PlayerCloseToChestListener implements Listener {
         Location lineLocation = spawnLocation.clone().subtract(0, 0.1, 0);
         String itemname = "Error";
         itemname = Utils.getFinalItemName(thatItem);
+        List<String> possibleCounts = Utils.calculatePossibleAmount(Bukkit.getOfflinePlayer(player.getUniqueId()),
+                Bukkit.getOfflinePlayer(UUID.fromString(((TileState) shopLocation.getBlock().getState()).getPersistentDataContainer()
+                        .get(new NamespacedKey(EzChestShop.getPlugin(), "owner"), PersistentDataType.STRING))), player.getInventory().getStorageContents(),
+                Utils.getBlockInventory(shopLocation.getBlock()).getStorageContents(),
+                buy, sell, thatItem);
         List<String> structure = new ArrayList<>(is_adminshop ? Config.holostructure_admin : Config.holostructure);
         if (ShopContainer.getShopSettings(shopLocation).getRotation().equals("down")) Collections.reverse(structure);
         for (String element : structure) {
@@ -255,7 +260,8 @@ public class PlayerCloseToChestListener implements Listener {
                 lineLocation.add(0, 0.35 * Config.holo_linespacing, 0);
             } else {
                 String line = Utils.colorify(element.replace("%item%", itemname).replace("%buy%", Utils.formatNumber(buy, Utils.FormatType.HOLOGRAM)).
-                        replace("%sell%", Utils.formatNumber(sell, Utils.FormatType.HOLOGRAM)).replace("%currency%", Config.currency).replace("%owner%", shop_owner));
+                        replace("%sell%", Utils.formatNumber(sell, Utils.FormatType.HOLOGRAM)).replace("%currency%", Config.currency)
+                        .replace("%owner%", shop_owner).replace("%maxbuy%", possibleCounts.get(0)).replace("%maxsell%", possibleCounts.get(1)));
                 if (is_dbuy || is_dsell) {
                     line = line.replaceAll("<separator>.*?<\\/separator>", "");
                     if (is_dbuy && is_dsell) {

--- a/src/main/java/me/deadlight/ezchestshop/Utils/Utils.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/Utils.java
@@ -1,5 +1,7 @@
 package me.deadlight.ezchestshop.Utils;
 import me.deadlight.ezchestshop.Utils.Objects.TransactionLogObject;
+import net.md_5.bungee.api.chat.*;
+import net.md_5.bungee.api.chat.hover.content.Text;
 import net.minecraft.nbt.NBTTagCompound;
 import org.bukkit.*;
 import me.deadlight.ezchestshop.Data.Config;
@@ -244,7 +246,7 @@ public class Utils {
         } else {
             itemname = Utils.capitalizeFirstSplit(item.getType().toString());
         }
-        return colorify(itemname);
+        return colorify(itemname).trim();
     }
 
 
@@ -645,6 +647,17 @@ public class Utils {
                 break;
         }
         return result;
+    }
+
+    public static void sendVersionMessage(Player player) {
+        player.spigot().sendMessage(new ComponentBuilder("Ez Chest Shop plugin, " + EzChestShop.getPlugin().getDescription().getVersion())
+                .color(net.md_5.bungee.api.ChatColor.GREEN)
+                .append("\nSpigot: ").color(net.md_5.bungee.api.ChatColor.GOLD).append("LINK").color(net.md_5.bungee.api.ChatColor.GRAY).bold(true)
+                .event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(colorify("&fClick to open the plugins Spigot page!"))))
+                .event(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://www.spigotmc.org/resources/ez-chest-shop-ecs-1-14-x-1-17-x.90411/"))
+                .append("\nGitHub: ", ComponentBuilder.FormatRetention.NONE).color(net.md_5.bungee.api.ChatColor.RED).append("LINK").color(net.md_5.bungee.api.ChatColor.GRAY).bold(true)
+                .event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(colorify("&fClick to chekc out the plugins\n Open Source GitHub repository!"))))
+                .event(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://github.com/ItzAmirreza/EzChestShop")).create());
     }
 
 

--- a/src/main/java/me/deadlight/ezchestshop/Utils/WorldGuard/FlagRegistry.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/WorldGuard/FlagRegistry.java
@@ -1,0 +1,46 @@
+package me.deadlight.ezchestshop.Utils.WorldGuard;
+
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.flags.BooleanFlag;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
+
+public class FlagRegistry {
+
+    // All the flags:
+
+    public static StateFlag CREATE_SHOP;
+    public static StateFlag CREATE_ADMIN_SHOP;
+    public static StateFlag REMOVE_SHOP;
+    public static StateFlag REMOVE_ADMIN_SHOP;
+    public static StateFlag USE_SHOP;
+    public static StateFlag USE_ADMIN_SHOP;
+
+    public static void onLoad() {
+        CREATE_SHOP = registerStateFlag("ecs-create-shop", true);
+        CREATE_ADMIN_SHOP = registerStateFlag("ecs-create-admin-shop", true);
+        REMOVE_SHOP = registerStateFlag("ecs-remove-shop", true);
+        REMOVE_ADMIN_SHOP = registerStateFlag("ecs-remove-admin-shop", true);
+        USE_SHOP = registerStateFlag("ecs-use-shop", true);
+        USE_ADMIN_SHOP = registerStateFlag("ecs-use-admin-shop", true);
+    }
+
+
+    // register a Boolean based flag:
+    private static StateFlag registerStateFlag(String name, boolean def) {
+        com.sk89q.worldguard.protection.flags.registry.FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
+        try {
+            StateFlag flag = new StateFlag(name, def);
+            registry.register(flag);
+            return flag;
+        } catch (FlagConflictException e) {
+            Flag<?> existing = registry.get(name);
+            if (existing instanceof BooleanFlag) {
+                return (StateFlag) existing;
+            }
+        }
+        //This will never run as there's a try catch above.
+        return null;
+    }
+}

--- a/src/main/java/me/deadlight/ezchestshop/Utils/WorldGuard/WorldGuardUtils.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/WorldGuard/WorldGuardUtils.java
@@ -1,0 +1,40 @@
+package me.deadlight.ezchestshop.Utils.WorldGuard;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.World;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.association.RegionAssociable;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import com.sk89q.worldguard.protection.regions.RegionQuery;
+import org.bukkit.entity.Player;
+
+public class WorldGuardUtils {
+
+    public static Location convertLocation(org.bukkit.Location loc) {
+        return BukkitAdapter.adapt(loc);
+    }
+
+    public static World convertWorld(org.bukkit.World world) {
+        return BukkitAdapter.adapt(world);
+    }
+
+    public static ApplicableRegionSet queryRegionSet(org.bukkit.Location loc) {
+        RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+        RegionQuery query = container.createQuery();
+        return  ((RegionQuery) query).getApplicableRegions(convertLocation(loc));
+    }
+
+    public static boolean queryStateFlag(StateFlag flag, Player player) {
+        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+        return queryRegionSet(player.getLocation()).testState(localPlayer, flag);
+    }
+
+    public static boolean queryStateFlag(StateFlag flag, org.bukkit.Location location) {
+        return queryRegionSet(location).testState(null, flag);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,8 @@ shops:
     # represents the holographic texts of chestshops. Use %item% to display the item's display name.
     # Use [item] for 1 Line to display the floating item. Use %buy% for buy price and %sell% for sell price.
     # %currency% is defined under economy.server-currency and %owner% represents the shops creator.
+    # %maxbuy% & %maxsell% can be used to define the maximum amount a player can buy/sell to a shop at this time.
+    # The HTML like <buy></buy> Syntax allows the plugin to remove parts of the message if buy/sell are disabled.
     holo-structure:
       - "<buy>&fBuy: &a%buy% %currency%</buy><separator> &f| </separator><sell>&fSell: &c%sell% %currency%</sell>"
       - "&d%item%"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,7 @@ api-version: 1.14
 depend: [Vault, ProtocolLib]
 softdepend:
   - WildChests
+  - WorldGuard
 authors: [ Dead_Light ]
 description: Easy Chest Shop that any server owner wants that for his players
 commands:

--- a/src/main/resources/translations/Locale_DE.yml
+++ b/src/main/resources/translations/Locale_DE.yml
@@ -211,7 +211,7 @@ command-messages:
   notachestorcs: "&cDer Block auf den du schaust ist keine Kiste/kein Kistenshop."
   maxShopLimitReached: "&cMaximale Shop Anzahl erreicht: %shoplimit%!"
   slimeFunBlockNotSupported: "&cLeider sind slimefun kisten nicht unterstützt! Bitte verwende einen anderen Container!"
-  buypriceGreaterThenSellRequired: "&cDer Kaufpreis muss größer als der Verkaufspreis sein!"
+  buypriceGreaterThanSellRequired: "&cDer Kaufpreis muss größer als der Verkaufspreis sein!"
 checkprofits:
   landing-menu:
     - '&e========================================'

--- a/src/main/resources/translations/Locale_EN.yml
+++ b/src/main/resources/translations/Locale_EN.yml
@@ -202,12 +202,12 @@ command-messages:
   notallowdtocreate: "&cYou are not allowed to create/remove a chest shop in this location."
   notchest: "&cThe block that you are looking at is not supported type of chest/is not a chest."
   lookatchest: "&cPlease look at a chest."
-  csremoved: "&eThis chest shop successfully removed."
+  csremoved: "&eThis chest shop has been successfully removed."
   notowner: "&aYou are not the owner of this chest shop!"
   notachestorcs: "&cThe block that you are looking at is not a chest/or this is not a chest shop."
   maxShopLimitReached: "&cMaximum shop limit reached: %shoplimit%!"
   slimeFunBlockNotSupported: "&cSorry :(, but you can't execute this command with a slimefun block / please use a normal block as a container"
-  buypriceGreaterThenSellRequired: "&cBuyPrice has to be greater then the SellPrice!"
+  buypriceGreaterThanSellRequired: "&cBuyPrice has to be greater then the SellPrice!"
 checkprofits:
   landing-menu:
     - '&e========================================'

--- a/src/main/resources/translations/Locale_FA.yml
+++ b/src/main/resources/translations/Locale_FA.yml
@@ -207,7 +207,7 @@ command-messages:
   notachestorcs: "&cBlocki darid negah mikonid yek chest ya yek chest shop nist."
   maxShopLimitReached: "&cShoma az in bishtar nemitavanid shop besazid. Hade aksar: %shoplimit% shop!"
   slimeFunBlockNotSupported: "&cBebakhshid :(, Shoma ghader be estefade az block haye slimefun baraye chest shop nistid, az yek block mamoli estefade konid."
-  buypriceGreaterThenSellRequired: "&cGheymate kharid az shoma bayad bozorg tar az gheymate forosh be shoma bashad."
+  buypriceGreaterThanSellRequired: "&cGheymate kharid az shoma bayad bozorg tar az gheymate forosh be shoma bashad."
 checkprofits:
   landing-menu:
     - '&e========================================'


### PR DESCRIPTION
- Implemented WorldGuard custom Flags.
- Available Flags are: ecs-create-shop, ecs-create-admin-shop, ecs-remove-shop, ecs-remove-admin-shop, ecs-use-shop, ecs-use-admin-shop.
- Added new possible hologram placeholders to define the max buy/sell amount using the same calculation as with the custom amount. (so player balances and inventories are considered too!)
- Added new admin permissions: ecs.admin is still the op overriding everything permission, however, all sub commands as well as Admin GUI view have got their own permission options now. ecs.admin.create, ecs.admin.remove, ecs.admin.reload, ecs.admin.view
- Merged the version command into a central one with Hover effects, as well as added a GitHub link (though I am not convinced by that idea completely)
- Fixed typo Then -> Than inside the languge ymls.
- Fixed Grammar error in Locale_EN.yml
- Added comments to config.yml explaining the new placeholders and syntax.
- Fixed additional space being added to the item name in getFinalItemName().
- The version number on enabling is now handled via the plugin description too. Less chances of forgetting about it :P