### PR TITLE
extra EzShop data | Database query speedup.

### DIFF
--- a/src/main/java/me/deadlight/ezchestshop/Data/SQLite/Database.java
+++ b/src/main/java/me/deadlight/ezchestshop/Data/SQLite/Database.java
@@ -1,12 +1,17 @@
 package me.deadlight.ezchestshop.Data.SQLite;
 
 import me.deadlight.ezchestshop.EzChestShop;
+import me.deadlight.ezchestshop.Utils.Objects.EzShop;
+import me.deadlight.ezchestshop.Utils.Objects.ShopSettings;
+import me.deadlight.ezchestshop.Utils.Utils;
+import org.bukkit.Location;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -778,5 +783,38 @@ public abstract class Database {
             }
         }
         return;
+    }
+
+    public HashMap<Location, EzShop> queryShops() {
+        Connection conn = null;
+        PreparedStatement ps = null;
+        ResultSet rs;
+        try {
+            conn = getSQLConnection();
+            ps = conn.prepareStatement("SELECT * FROM shopdata;");
+
+            rs = ps.executeQuery();
+            HashMap<Location, EzShop> map = new HashMap<>();
+            while (rs.next()) {
+                String sloc = rs.getString("location");
+                map.put(Utils.StringtoLocation(sloc), new EzShop(Utils.StringtoLocation(sloc), rs.getString("owner"), Utils.decodeItem(rs.getString("item")),
+                        rs.getDouble("buyPrice"), rs.getDouble("sellPrice"), new ShopSettings(sloc, rs.getBoolean("msgToggle"),
+                        rs.getBoolean("buyDisabled"), rs.getBoolean("sellDisabled"), rs.getString("admins"),
+                        rs.getBoolean("shareIncome"), rs.getString("transactions"), rs.getBoolean("adminshop"), rs.getString("rotation"))));
+            }
+            return map;
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, Errors.sqlConnectionExecute(), e);
+        } finally {
+            try {
+                if (ps != null)
+                    ps.close();
+                if (conn != null)
+                    conn.close();
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.SEVERE, Errors.sqlConnectionClose(), e);
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/me/deadlight/ezchestshop/Data/ShopContainer.java
+++ b/src/main/java/me/deadlight/ezchestshop/Data/ShopContainer.java
@@ -37,29 +37,8 @@ public class ShopContainer {
      */
     public static void queryShopsToMemory() {
         Database db = EzChestShop.getPlugin().getDatabase();
-        for (String sloc : db.getKeys("location", "shopdata")) {
-            boolean msgtoggle = db.getBool("location", sloc,
-                    "msgToggle", "shopdata");
-            boolean dbuy =  db.getBool("location", sloc,
-                    "buyDisabled", "shopdata");
-            boolean dsell = db.getBool("location", sloc,
-                    "sellDisabled", "shopdata");
-            String admins = db.getString("location", sloc,
-                    "admins", "shopdata");
-            boolean shareincome = db.getBool("location", sloc,
-                    "shareIncome", "shopdata");
-            String trans = db.getString("location", sloc,
-                    "transactions", "shopdata");
-            boolean adminshop = db.getBool("location", sloc,
-                    "adminshop", "shopdata");
-            String rotation = db.getString("location", sloc,
-                    "rotation", "shopdata");
-            rotation = rotation == null ? Config.settings_defaults_rotation : rotation;
-            ShopSettings settings = new ShopSettings(sloc, msgtoggle, dbuy, dsell, admins, shareincome, trans, adminshop, rotation);
-            Location loc = Utils.StringtoLocation(sloc);
-            EzShop shop = new EzShop(loc, settings);
-            shopMap.put(loc, shop);
-        }
+        shopMap = db.queryShops();
+
     }
 
     /**
@@ -92,7 +71,7 @@ public class ShopContainer {
         String encodedItem = Utils.encodeItem(item);
         db.insertShop(sloc, p.getUniqueId().toString(), encodedItem == null ? "Error" : encodedItem, buyprice, sellprice, msgtoggle, dbuy, dsell, admins, shareincome, trans, adminshop, rotation);
         ShopSettings settings = new ShopSettings(sloc, msgtoggle, dbuy, dsell, admins, shareincome, trans, adminshop, rotation);
-        EzShop shop = new EzShop(loc, settings);
+        EzShop shop = new EzShop(loc, p, item, buyprice, sellprice, settings);
         shopMap.put(loc, shop);
     }
 
@@ -117,7 +96,7 @@ public class ShopContainer {
         db.insertShop(sloc, owner, encodedItem == null ? "Error" : encodedItem, buyprice, sellprice, msgtoggle, dbuy, dsell, admins, shareincome, trans, adminshop, rotation);
 
         ShopSettings settings = new ShopSettings(sloc, msgtoggle, dbuy, dsell, admins, shareincome, trans, adminshop, rotation);
-        EzShop shop = new EzShop(loc, settings);
+        EzShop shop = new EzShop(loc, owner, Utils.decodeItem(encodedItem), buyprice, sellprice, settings);
         shopMap.put(loc, shop);;
     }
 
@@ -205,7 +184,7 @@ public class ShopContainer {
             String rotation = dataContainer.get(new NamespacedKey(EzChestShop.getPlugin(), "rotation"), PersistentDataType.STRING);
             rotation = rotation == null ? Config.settings_defaults_rotation : rotation;
             ShopSettings settings = new ShopSettings(sloc, msgtoggle, dbuy, dsell, admins, shareincome, trans, adminshop, rotation);
-            EzShop shop = new EzShop(loc, settings);
+            EzShop shop = new EzShop(loc, owner, Utils.decodeItem(encodedItem), buyprice, sellprice, settings);
             shopMap.put(loc, shop);
             return settings;
         }

--- a/src/main/java/me/deadlight/ezchestshop/Utils/Objects/EzShop.java
+++ b/src/main/java/me/deadlight/ezchestshop/Utils/Objects/EzShop.java
@@ -1,19 +1,44 @@
 package me.deadlight.ezchestshop.Utils.Objects;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class EzShop {
 
     private Location location;
     private ShopSettings settings;
+    private OfflinePlayer owner;
+    private ItemStack shopItem;
+    private double buyPrice;
+    private double sellPrice;
+
     private List<String> shopViewers = new ArrayList<>();
+    private List<String> shopLoaders = new ArrayList<>();
 
 
-    public EzShop(Location location, ShopSettings settings) {
+
+    public EzShop(Location location, OfflinePlayer owner, ItemStack shopItem, double buyPrice, double sellPrice, ShopSettings settings) {
         this.location = location;
+        this.owner = owner;
+        this.shopItem = shopItem;
+        this.buyPrice = buyPrice;
+        this.sellPrice = sellPrice;
+        this.settings = settings;
+    }
+
+    public EzShop(Location location, String ownerID, ItemStack shopItem, double buyPrice, double sellPrice, ShopSettings settings) {
+        this.location = location;
+        this.owner = Bukkit.getOfflinePlayer(UUID.fromString(ownerID));
+        this.shopItem = shopItem;
+        this.buyPrice = buyPrice;
+        this.sellPrice = sellPrice;
         this.settings = settings;
     }
 
@@ -25,6 +50,9 @@ public class EzShop {
     }
     public List<String> getShopViewers() {
         return shopViewers;
+    }
+    public List<String> getShopLoaders() {
+        return shopLoaders;
     }
     public void setLocation(Location location) {
         this.location = location;
@@ -41,6 +69,16 @@ public class EzShop {
     }
     public void removeShopViewer(String str) {
         this.shopViewers.remove(str);
+    }
+    public void setShopLoaders(List<String> shopLoaders) {
+        this.shopLoaders = shopLoaders;
+    }
+    public void addShopLoader(String str) {
+        if (this.shopLoaders.contains(str)) return;
+        this.shopLoaders.add(str);
+    }
+    public void removeShopLoader(String str) {
+        this.shopLoaders.remove(str);
     }
 
 }


### PR DESCRIPTION
- Added additional Data to the EzShop Object for potential usage in the Holograms later.
- Added separate List for Hologram Loaders. (Viewers is for looking directly at a shop, Loaders is for people Loading the Hologram because they are close to it)
- Improved the initial Database querying by having all the data queried in one place from one call, instead of making multiple calls per shop per data column, it's now a single call.