### PR TITLE
Folia support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -215,5 +215,11 @@
             <version>3.5.3</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.Anon8281</groupId>
+            <artifactId>UniversalScheduler</artifactId>
+            <version>0.1.6</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/me/deadlight/ezchestshop/EzChestShop.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/EzChestShop.java
@@ -1,4 +1,6 @@
 package me.deadlight.ezchestshop;
+import com.github.Anon8281.universalScheduler.UniversalScheduler;
+import com.github.Anon8281.universalScheduler.scheduling.schedulers.TaskScheduler;
 import me.deadlight.ezchestshop.commands.CommandCheckProfits;
 import me.deadlight.ezchestshop.commands.EcsAdmin;
 import me.deadlight.ezchestshop.commands.MainCommands;
@@ -36,6 +38,15 @@ public final class EzChestShop extends JavaPlugin {
     public static boolean worldguard = false;
     public static boolean advancedregionmarket = false;
 
+    private static TaskScheduler scheduler;
+
+    /**
+     * Get the scheduler of the plugin
+     */
+    public static TaskScheduler getScheduler() {
+        return scheduler;
+    }
+
     @Override
     public void onLoad() {
         // Adds Custom Flags to WorldGuard!
@@ -49,6 +60,7 @@ public final class EzChestShop extends JavaPlugin {
     public void onEnable() {
 
         plugin = this;
+        scheduler = UniversalScheduler.getScheduler(this);
         logConsole("&c[&eEzChestShop&c] &aEnabling EzChestShop - version " + this.getDescription().getVersion());
         saveDefaultConfig();
 
@@ -330,7 +342,8 @@ public final class EzChestShop extends JavaPlugin {
     @Override
     public void onDisable() {
         // Plugin shutdown logic
-        getServer().getScheduler().cancelTasks(this);
+        if(scheduler != null)
+            scheduler.cancelTasks();
         logConsole("&c[&eEzChestShop&c] &bSaving remained sql cache...");
         ShopContainer.saveSqlQueueCache();
 

--- a/core/src/main/java/me/deadlight/ezchestshop/Metrics.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/Metrics.java
@@ -77,7 +77,7 @@ public class Metrics {
                         enabled,
                         this::appendPlatformData,
                         this::appendServiceData,
-                        submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
+                        submitDataTask -> EzChestShop.getScheduler().runTask(submitDataTask),
                         plugin::isEnabled,
                         (message, error) -> this.plugin.getLogger().log(Level.WARNING, message, error),
                         (message) -> this.plugin.getLogger().log(Level.INFO, message),

--- a/core/src/main/java/me/deadlight/ezchestshop/commands/CommandCheckProfits.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/commands/CommandCheckProfits.java
@@ -133,7 +133,7 @@ public class CommandCheckProfits implements CommandExecutor, Listener, TabComple
             return;
         else if (checkprofits.get(0).getItem() == null)
             return;
-        Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> p.spigot().sendMessage(lm.joinProfitNotification()), 4l);
+        EzChestShop.getScheduler().runTaskLater(() -> p.spigot().sendMessage(lm.joinProfitNotification()), 4l);
     }
 
     @Override

--- a/core/src/main/java/me/deadlight/ezchestshop/commands/MainCommands.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/commands/MainCommands.java
@@ -1103,13 +1103,13 @@ public class MainCommands implements CommandExecutor, TabCompleter {
             List<Block> blocks = Utils.getNearbyEmptyShopForAdmins(player);
             player.sendMessage(lm.emptyShopHighlightedEnabled(blocks.size()));
             AtomicInteger actionBarCounter = new AtomicInteger();
-            EzChestShop.getPlugin().getServer().getScheduler().runTaskLaterAsynchronously(EzChestShop.getPlugin(), () -> {
+            EzChestShop.getScheduler().runTaskLaterAsynchronously(EzChestShop.getPlugin(), () -> {
 
                 //Iterate through each block with an asychronous delay of 5 ticks
                 blocks.forEach(b -> {
                     BlockOutline outline = new BlockOutline(player, b);
                     int index = blocks.indexOf(b);
-                    EzChestShop.getPlugin().getServer().getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                         outline.showOutline();
                         if (outline.muted) {
                             return;

--- a/core/src/main/java/me/deadlight/ezchestshop/data/ShopContainer.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/data/ShopContainer.java
@@ -514,7 +514,7 @@ public class ShopContainer {
 
 
     public static void startSqlQueueTask() {
-        Bukkit.getScheduler().runTaskTimer(EzChestShop.getPlugin(), new Runnable() {
+        EzChestShop.getScheduler().runTaskTimer(EzChestShop.getPlugin(), new Runnable() {
             @Override
             public void run() {
 

--- a/core/src/main/java/me/deadlight/ezchestshop/data/mysql/MySQL.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/data/mysql/MySQL.java
@@ -136,12 +136,12 @@ public class MySQL extends DatabaseManager {
     public void deleteEntry(String primary_key, String key, String table) {
         EzqlTable ezqlTable = database.getTable(prefix+table);
 
-        Bukkit.getScheduler().runTaskAsynchronously(plugin,()->ezqlTable.removeRows(primary_key, key));
+        EzChestShop.getScheduler().runTaskAsynchronously(plugin,()->ezqlTable.removeRows(primary_key, key));
     }
 
     @Override
     public void insertShop(String sloc, String owner, String item, double buyprice, double sellprice, boolean msgtoggle, boolean dbuy, boolean dsell, String admins, boolean shareincome, boolean adminshop, String rotation, List<String> customMessages) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin,()->this.shopdata.pushRow(
+        EzChestShop.getScheduler().runTaskAsynchronously(plugin,()->this.shopdata.pushRow(
                 sloc,
                 owner,
                 item,
@@ -169,28 +169,28 @@ public class MySQL extends DatabaseManager {
     public void setString(String primary_key, String key, String column, String table, String data) {
         EzqlTable ezqlTable = database.getTable(prefix+table);
 
-        Bukkit.getScheduler().runTaskAsynchronously(plugin,()->ezqlTable.updateRow(primary_key, key, new EzqlRow(column, data)));
+        EzChestShop.getScheduler().runTaskAsynchronously(plugin,()->ezqlTable.updateRow(primary_key, key, new EzqlRow(column, data)));
     }
 
     @Override
     public void setInt(String primary_key, String key, String column, String table, int data) {
         EzqlTable ezqlTable = database.getTable(prefix+table);
 
-        Bukkit.getScheduler().runTaskAsynchronously(plugin,()->ezqlTable.updateRow(primary_key, key, new EzqlRow(column, data)));
+        EzChestShop.getScheduler().runTaskAsynchronously(plugin,()->ezqlTable.updateRow(primary_key, key, new EzqlRow(column, data)));
     }
 
     @Override
     public void setBool(String primary_key, String key, String column, String table, Boolean data) {
         EzqlTable ezqlTable = database.getTable(prefix+table);
 
-        Bukkit.getScheduler().runTaskAsynchronously(plugin,()->ezqlTable.updateRow(primary_key, key, new EzqlRow(column, data ? 1 : 0)));
+        EzChestShop.getScheduler().runTaskAsynchronously(plugin,()->ezqlTable.updateRow(primary_key, key, new EzqlRow(column, data ? 1 : 0)));
     }
 
     @Override
     public void setDouble(String primary_key, String key, String column, String table, double data) {
         EzqlTable ezqlTable = database.getTable(prefix+table);
 
-        Bukkit.getScheduler().runTaskAsynchronously(plugin,()->ezqlTable.updateRow(primary_key, key, new EzqlRow(column, data)));
+        EzChestShop.getScheduler().runTaskAsynchronously(plugin,()->ezqlTable.updateRow(primary_key, key, new EzqlRow(column, data)));
     }
 
 
@@ -208,6 +208,6 @@ public class MySQL extends DatabaseManager {
 
     @Override
     public void preparePlayerData(String table, String uuid) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin,()->playerdata.pushRow(uuid,""));
+        EzChestShop.getScheduler().runTaskAsynchronously(plugin,()->playerdata.pushRow(uuid,""));
     }
 }

--- a/core/src/main/java/me/deadlight/ezchestshop/data/mysql/MySQL.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/data/mysql/MySQL.java
@@ -28,6 +28,9 @@ public class MySQL extends DatabaseManager {
         this.plugin = plugin;
     }
 
+    //TODO Don't forget to change this when adding a new database table that works with Player data!
+    public static List<String> playerTables = Arrays.asList("playerdata");
+
 
     @Override
     public void load() {

--- a/core/src/main/java/me/deadlight/ezchestshop/guis/AdminShopGUI.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/guis/AdminShopGUI.java
@@ -232,12 +232,7 @@ public class AdminShopGUI {
                                             player.sendMessage(lm.unsupportedInteger());
                                             return false;
                                         }
-                                        Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(), new Runnable() {
-                                            @Override
-                                            public void run() {
-                                                ShopContainer.buyItem(containerBlock, buyPrice * amount, amount, mainitem, player, offlinePlayerOwner, data);
-                                            }
-                                        });
+                                        EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> ShopContainer.buyItem(containerBlock, buyPrice * amount, amount, mainitem, player, offlinePlayerOwner, data));
                                     } else {
                                         thatplayer.sendMessage(lm.wrongInput());
                                     }
@@ -273,12 +268,7 @@ public class AdminShopGUI {
                                             player.sendMessage(lm.unsupportedInteger());
                                             return false;
                                         }
-                                        Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(), new Runnable() {
-                                            @Override
-                                            public void run() {
-                                                ShopContainer.sellItem(containerBlock, sellPrice * amount, amount, mainitem, player, offlinePlayerOwner, data);
-                                            }
-                                        });
+                                        EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> ShopContainer.sellItem(containerBlock, sellPrice * amount, amount, mainitem, player, offlinePlayerOwner, data));
                                     } else {
                                         thatplayer.sendMessage(lm.wrongInput());
                                     }

--- a/core/src/main/java/me/deadlight/ezchestshop/guis/NonOwnerShopGUI.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/guis/NonOwnerShopGUI.java
@@ -178,12 +178,7 @@ public class NonOwnerShopGUI {
                                             player.sendMessage(lm.unsupportedInteger());
                                             return false;
                                         }
-                                        Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(), new Runnable() {
-                                            @Override
-                                            public void run() {
-                                                ShopContainer.buyItem(containerBlock, buyPrice * amount, amount, mainitem, player, offlinePlayerOwner, data);
-                                            }
-                                        });
+                                        EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> ShopContainer.buyItem(containerBlock, buyPrice * amount, amount, mainitem, player, offlinePlayerOwner, data));
                                     } else {
                                         thatplayer.sendMessage(lm.wrongInput());
                                     }
@@ -218,12 +213,7 @@ public class NonOwnerShopGUI {
                                             player.sendMessage(lm.unsupportedInteger());
                                             return false;
                                         }
-                                        Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(), new Runnable() {
-                                            @Override
-                                            public void run() {
-                                                ShopContainer.sellItem(containerBlock, sellPrice * amount, amount, mainitem, player, offlinePlayerOwner, data);
-                                            }
-                                        });
+                                        EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> ShopContainer.sellItem(containerBlock, sellPrice * amount, amount, mainitem, player, offlinePlayerOwner, data));
                                     } else {
                                         thatplayer.sendMessage(lm.wrongInput());
                                     }

--- a/core/src/main/java/me/deadlight/ezchestshop/guis/ServerShopGUI.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/guis/ServerShopGUI.java
@@ -199,8 +199,7 @@ public class ServerShopGUI {
                                             player.sendMessage(lm.unsupportedInteger());
                                             return false;
                                         }
-                                        Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(),
-                                                () -> ShopContainer.buyServerItem(containerBlock, buyPrice * amount, amount, thatplayer, mainitem, data));
+                                        EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> ShopContainer.buyServerItem(containerBlock, buyPrice * amount, amount, thatplayer, mainitem, data));
                                     } else {
                                         thatplayer.sendMessage(lm.wrongInput());
                                     }
@@ -235,8 +234,7 @@ public class ServerShopGUI {
                                             player.sendMessage(lm.unsupportedInteger());
                                             return false;
                                         }
-                                        Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(),
-                                                () -> ShopContainer.sellServerItem(containerBlock, sellPrice * amount, amount, mainitem, thatplayer, data));
+                                        EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> ShopContainer.sellServerItem(containerBlock, sellPrice * amount, amount, mainitem, thatplayer, data));
                                     } else {
                                         thatplayer.sendMessage(lm.wrongInput());
                                     }

--- a/core/src/main/java/me/deadlight/ezchestshop/guis/SettingsGUI.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/guis/SettingsGUI.java
@@ -324,8 +324,7 @@ public class SettingsGUI {
                                             player.sendMessage(lm.negativePrice());
                                             return false;
                                         }
-                                        Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(),
-                                                () -> {
+                                        EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> {
                                                     // If these checks complete successfully continue.
                                                     if (changePrice(containerBlock.getState(), false, amount, player, containerBlock)) {
                                                         ShopContainer.changePrice(containerBlock.getState(), amount, false);
@@ -359,8 +358,7 @@ public class SettingsGUI {
                                             player.sendMessage(lm.negativePrice());
                                             return false;
                                         }
-                                        Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(),
-                                                () -> {
+                                        EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> {
                                                     // If these checks complete successfully continue.
                                                     if (changePrice(containerBlock.getState(), true, amount, player, containerBlock)) {
                                                         ShopContainer.changePrice(containerBlock.getState(), amount, true);
@@ -583,8 +581,7 @@ public class SettingsGUI {
                  .reopenIfFail(false).response((thatplayer, strings) -> {
                      try {
                          // Run checks here if allowed
-                         Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(),
-                                 () -> {
+                         EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> {
                                      int lines = Config.settings_hologram_message_line_count_default;
                                      if (Config.permission_hologram_message_line_count) {
                                          int maxShops = Utils.getMaxPermission(player, "ecs.shops.hologram.messages.lines.");

--- a/core/src/main/java/me/deadlight/ezchestshop/listeners/BlockPistonExtendListener.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/listeners/BlockPistonExtendListener.java
@@ -79,7 +79,7 @@ public class BlockPistonExtendListener implements Listener {
                         if (Config.holodistancing) {
                             ShopHologram.hideForAll(event.getBlock().getLocation());
                         }
-                        Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(), () -> {
+                        EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> {
 
                             Collection<Entity> entitiyList = block.getWorld().getNearbyEntities(shulkerLoc, 2, 2, 2);
                             entitiyList.forEach(entity -> {

--- a/core/src/main/java/me/deadlight/ezchestshop/listeners/BlockPlaceListener.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/listeners/BlockPlaceListener.java
@@ -34,7 +34,7 @@ public class BlockPlaceListener implements Listener {
         if (state instanceof Dispenser) {
             Dispenser dispenser = ((Dispenser) state);
             final Directional directional = (Directional) dispenser.getBlockData();
-            Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(), () -> {
+            EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> {
                 Block block = event.getBlock().getRelative(directional.getFacing());
                 ItemStack item = event.getItem();
                 placeBlock(block, item);

--- a/core/src/main/java/me/deadlight/ezchestshop/listeners/ChatListener.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/listeners/ChatListener.java
@@ -60,21 +60,15 @@ public class ChatListener implements Listener {
 
                 if (type.equalsIgnoreCase("add")) {
                     chatmap.remove(player.getUniqueId());
-                    Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(), new Runnable() {
-                        @Override
-                        public void run() {
-                            addThePlayer(event.getMessage(), chest, player);
-                            guiInstance.showGUI(player, chest, false);
-                        }
+                    EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> {
+                        addThePlayer(event.getMessage(), chest, player);
+                        guiInstance.showGUI(player, chest, false);
                     }, 0);
                 } else {
                     chatmap.remove(player.getUniqueId());
-                    Bukkit.getScheduler().scheduleSyncDelayedTask(EzChestShop.getPlugin(), new Runnable() {
-                        @Override
-                        public void run() {
-                            removeThePlayer(event.getMessage(), chest, player);
-                            guiInstance.showGUI(player, chest, false);
-                        }
+                    EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> {
+                        removeThePlayer(event.getMessage(), chest, player);
+                        guiInstance.showGUI(player, chest, false);
                     }, 0);
                 }
 

--- a/core/src/main/java/me/deadlight/ezchestshop/listeners/PlayerCloseToChestListener.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/listeners/PlayerCloseToChestListener.java
@@ -191,7 +191,7 @@ public class PlayerCloseToChestListener implements Listener {
     @EventHandler
     public void onShopContentsChangeByBlock(InventoryMoveItemEvent event) {
         if (!event.isCancelled() && ShopContainer.isShop(event.getDestination().getLocation())) {
-            Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> ShopHologram.updateInventoryReplacements(event.getDestination().getLocation()), 1);
+            EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> ShopHologram.updateInventoryReplacements(event.getDestination().getLocation()), 1);
         }
     }
 
@@ -214,7 +214,7 @@ public class PlayerCloseToChestListener implements Listener {
     public void onInventoryChangeByPlayerItemPickup(EntityPickupItemEvent event) {
         if (!event.isCancelled() && event.getEntity().getType() == EntityType.PLAYER) {
             ShopHologram.getViewedHolograms((Player) event.getEntity()).forEach(shopHolo -> {
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> ShopHologram.updateInventoryReplacements(shopHolo.getLocation()), 1);
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> ShopHologram.updateInventoryReplacements(shopHolo.getLocation()), 1);
             });
         }
     }
@@ -222,7 +222,7 @@ public class PlayerCloseToChestListener implements Listener {
     @EventHandler
     public void onShopCapacityChangeByBlockPlace(BlockPlaceEvent event) {
         if (!event.isCancelled() && (event.getBlockPlaced().getType() == Material.CHEST || event.getBlockPlaced().getType() == Material.TRAPPED_CHEST)) {
-            Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+            EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                 Location location = BlockBoundHologram.getShopChestLocation(event.getBlockPlaced());
                 if (ShopContainer.isShop(location)) {
                     ShopHologram.updateInventoryReplacements(location);
@@ -238,20 +238,20 @@ public class PlayerCloseToChestListener implements Listener {
 //        if (!event.isCancelled() && (event.getBlock().getType() == Material.CHEST || event.getBlock().getType() == Material.TRAPPED_CHEST)) {
 //            Location location = BlockBoundHologram.getShopChestLocation(event.getBlock());
 //            if (ShopContainer.isShop(location)) {
-//                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> ShopHologram.updateInventoryReplacements(location), 1);
+//                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> ShopHologram.updateInventoryReplacements(location), 1);
 //            }
 //        }
 //    }
 
     @EventHandler
     public void onShopTransactionCapacityChange(PlayerTransactEvent event) {
-        Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> ShopHologram.updateInventoryReplacements(event.getContainerBlock().getLocation()), 1);
+        EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> ShopHologram.updateInventoryReplacements(event.getContainerBlock().getLocation()), 1);
     }
 
     private void inventoryModifyEventHandler(boolean cancelled, HumanEntity whoClicked) {
         if (!cancelled) {
             ShopHologram.getViewedHolograms((Player) whoClicked).forEach(shopHolo -> {
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> ShopHologram.updateInventoryReplacements(shopHolo.getLocation()), 1);
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> ShopHologram.updateInventoryReplacements(shopHolo.getLocation()), 1);
             });
         }
     }

--- a/core/src/main/java/me/deadlight/ezchestshop/listeners/PlayerJoinListener.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/listeners/PlayerJoinListener.java
@@ -29,7 +29,8 @@ public class PlayerJoinListener implements Listener {
     @EventHandler
     public void onJoin(PlayerJoinEvent event) throws NoSuchFieldException, IllegalAccessException {
         Player player = event.getPlayer();
-        Utils.versionUtils.injectConnection(player);
+        if(player != null)
+            Utils.versionUtils.injectConnection(player);
         /**
          * Prepare the database player values.
          *
@@ -73,7 +74,7 @@ public class PlayerJoinListener implements Listener {
             tones.add(Note.Tone.F);
             tones.add(Note.Tone.G);
             AtomicInteger actionBarCounter = new AtomicInteger();
-            EzChestShop.getPlugin().getServer().getScheduler().runTaskLaterAsynchronously(EzChestShop.getPlugin(), () -> {
+            EzChestShop.getScheduler().runTaskLaterAsynchronously(EzChestShop.getPlugin(), () -> {
 
                 //Iterate through each block with an asychronous delay of 5 ticks
                 blocks.forEach(b -> {

--- a/core/src/main/java/me/deadlight/ezchestshop/listeners/PlayerJoinListener.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/listeners/PlayerJoinListener.java
@@ -3,8 +3,10 @@ package me.deadlight.ezchestshop.listeners;
 import me.deadlight.ezchestshop.data.Config;
 import me.deadlight.ezchestshop.data.DatabaseManager;
 import me.deadlight.ezchestshop.data.LanguageManager;
+import me.deadlight.ezchestshop.data.mysql.MySQL;
 import me.deadlight.ezchestshop.data.sqlite.SQLite;
 import me.deadlight.ezchestshop.EzChestShop;
+import me.deadlight.ezchestshop.enums.Database;
 import me.deadlight.ezchestshop.utils.BlockOutline;
 import me.deadlight.ezchestshop.utils.Utils;
 import org.bukkit.Instrument;
@@ -35,13 +37,24 @@ public class PlayerJoinListener implements Listener {
          */
         DatabaseManager db = EzChestShop.getPlugin().getDatabase();
         UUID uuid = event.getPlayer().getUniqueId();
-        SQLite.playerTables.forEach(t -> {
-            if (db.hasTable(t)) {
-                if (!db.hasPlayer(t, uuid)) {
-                    db.preparePlayerData(t, uuid.toString());
+        if(Config.database_type.equals(Database.MYSQL)) {
+
+            MySQL.playerTables.forEach(t -> {
+                if (db.hasTable(t)) {
+                    if (!db.hasPlayer(t, uuid)) {
+                        db.preparePlayerData(t, uuid.toString());
+                    }
                 }
-            }
-        });
+            });
+        } else if (Config.database_type.equals(Database.SQLITE)) {
+            SQLite.playerTables.forEach(t -> {
+                if (db.hasTable(t)) {
+                    if (!db.hasPlayer(t, uuid)) {
+                        db.preparePlayerData(t, uuid.toString());
+                    }
+                }
+            });
+        }
 
 
         if (Config.emptyShopNotificationOnJoin) {

--- a/core/src/main/java/me/deadlight/ezchestshop/listeners/PlayerLookingAtChestShop.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/listeners/PlayerLookingAtChestShop.java
@@ -243,7 +243,7 @@ public class PlayerLookingAtChestShop implements Listener {
 
 
 
-        Bukkit.getScheduler().scheduleAsyncDelayedTask(EzChestShop.getPlugin(), () -> {
+        EzChestShop.getScheduler().scheduleSyncDelayedTask(() -> {
             for (ASHologram holo : holoTextList) {
                 holo.destroy();
                 Utils.onlinePackets.remove(holo);

--- a/core/src/main/java/me/deadlight/ezchestshop/listeners/UpdateChecker.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/listeners/UpdateChecker.java
@@ -46,18 +46,18 @@ public class UpdateChecker implements Listener{
     public void onJoin(PlayerJoinEvent event) {
         if (event.getPlayer().isOp()) {
             if (Config.notify_updates && isSpigotUpdateAvailable) {
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     event.getPlayer().spigot().sendMessage(lm.updateNotification(EzChestShop.getPlugin().getDescription().getVersion(), newVersion));
                 }, 10l);
             }
             if (isGuiUpdateAvailable) {
                 if (Config.notify_overflowing_gui_items && !requiredOverflowRows.isEmpty()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                         event.getPlayer().spigot().sendMessage(lm.overflowingGuiItemsNotification(requiredOverflowRows));
                     }, 10l);
                 }
                 if (Config.notify_overlapping_gui_items && !overlappingItems.isEmpty()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                         event.getPlayer().spigot().sendMessage(lm.overlappingItemsNotification(overlappingItems));
                     }, 10l);
                 }

--- a/core/src/main/java/me/deadlight/ezchestshop/tasks/LoadedChunksTask.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/tasks/LoadedChunksTask.java
@@ -10,15 +10,12 @@ import org.bukkit.World;
 public class LoadedChunksTask {
 
     public static void startTask() {
-        Bukkit.getScheduler().scheduleSyncRepeatingTask(EzChestShop.getPlugin(), (Runnable)new Runnable() {
-            @Override
-            public void run() {
-                //fix credited to Huke
-                for (final EzShop shop : ShopContainer.getShops()) {
-                    final World world = shop.getLocation().getWorld();
-                    if (world != null && world.isChunkLoaded(shop.getLocation().getBlockX() >> 4, shop.getLocation().getBlockZ() >> 4) && (shop.getLocation().getBlock().isEmpty() || !Utils.isApplicableContainer(shop.getLocation().getBlock()))) {
-                        ShopContainer.deleteShop(shop.getLocation());
-                    }
+        EzChestShop.getScheduler().scheduleSyncRepeatingTask(() -> {
+            //fix credited to Huke
+            for (final EzShop shop : ShopContainer.getShops()) {
+                final World world = shop.getLocation().getWorld();
+                if (world != null && world.isChunkLoaded(shop.getLocation().getBlockX() >> 4, shop.getLocation().getBlockZ() >> 4) && (shop.getLocation().getBlock().isEmpty() || !Utils.isApplicableContainer(shop.getLocation().getBlock()))) {
+                    ShopContainer.deleteShop(shop.getLocation());
                 }
             }
         }, 0L, 200L);

--- a/core/src/main/java/me/deadlight/ezchestshop/utils/FloatingItem.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/FloatingItem.java
@@ -17,9 +17,14 @@ public class FloatingItem {
 
     static {
         try {
-            String packageName = Utils.class.getPackage().getName();
-            String internalsName = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-            versionUtils = (VersionUtils) Class.forName(packageName + "." + internalsName).newInstance();
+            if(Class.forName("io.papermc.paper.threadedregions.RegionizedServer") != null) {
+                // TODO: Do a better check for Folia, currently will just use 1.20.4 if it's folia
+                versionUtils = (VersionUtils) Class.forName("me.deadlight.ezchestshop.utils.v1_20_R4").newInstance();
+            } else {
+                String packageName = Utils.class.getPackage().getName();
+                String internalsName = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+                versionUtils = (VersionUtils) Class.forName(packageName + "." + internalsName).newInstance();
+            }
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException exception) {
             Bukkit.getLogger().log(Level.SEVERE, "EzChestShop could not find a valid implementation for this server version.");
         }

--- a/core/src/main/java/me/deadlight/ezchestshop/utils/ImprovedOfflinePlayer.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/ImprovedOfflinePlayer.java
@@ -15,13 +15,16 @@ public abstract class ImprovedOfflinePlayer {
 
     static {
         try {
-            String packageName = Utils.class.getPackage().getName();
-            String internalsName = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-            improvedOfflinePlayer = (ImprovedOfflinePlayer) Class.forName(packageName + ".ImprovedOfflinePlayer_" + internalsName).newInstance();
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-                 | ClassCastException exception) {
-            Bukkit.getLogger().log(Level.SEVERE,
-                    "EzChestShop could not find a valid implementation for this server version. " + exception.getMessage());
+            if(Class.forName("io.papermc.paper.threadedregions.RegionizedServer") != null) {
+                // TODO: Do a better check for Folia, currently will just use 1.20.4 if it's folia
+                improvedOfflinePlayer = (ImprovedOfflinePlayer) Class.forName("me.deadlight.ezchestshop.utils.ImprovedOfflinePlayer_v1_20_R4").newInstance();
+            } else {
+                String packageName = Utils.class.getPackage().getName();
+                String internalsName = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+                improvedOfflinePlayer = (ImprovedOfflinePlayer) Class.forName(packageName + ".ImprovedOfflinePlayer_" + internalsName).newInstance();
+            }
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException exception) {
+            Bukkit.getLogger().log(Level.SEVERE, "EzChestShop could not find a valid implementation for this server version.");
         }
     }
 

--- a/core/src/main/java/me/deadlight/ezchestshop/utils/Utils.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/utils/Utils.java
@@ -63,13 +63,16 @@ public class Utils {
 
     static {
         try {
-            String packageName = Utils.class.getPackage().getName();
-            String internalsName = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-            versionUtils = (VersionUtils) Class.forName(packageName + "." + internalsName).newInstance();
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-                | ClassCastException exception) {
-            Bukkit.getLogger().log(Level.SEVERE,
-                    "EzChestShop could not find a valid implementation for this server version.");
+            if(Class.forName("io.papermc.paper.threadedregions.RegionizedServer") != null) {
+                // TODO: Do a better check for Folia, currently will just use 1.20.4 if it's folia
+                versionUtils = (VersionUtils) Class.forName("me.deadlight.ezchestshop.utils.v1_20_R4").newInstance();
+            } else {
+                String packageName = Utils.class.getPackage().getName();
+                String internalsName = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+                versionUtils = (VersionUtils) Class.forName(packageName + "." + internalsName).newInstance();
+            }
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ClassCastException exception) {
+            Bukkit.getLogger().log(Level.SEVERE, "EzChestShop could not find a valid implementation for this server version.");
         }
     }
 

--- a/core/src/main/java/tr/zeltuv/ezql/objects/EzqlDatabase.java
+++ b/core/src/main/java/tr/zeltuv/ezql/objects/EzqlDatabase.java
@@ -62,7 +62,6 @@ public class EzqlDatabase {
         HikariConfig hikariConfig = customHikariSettings.getHikariConfig(credentials);
 
         hikariDataSource = new HikariDataSource(hikariConfig);
-        hikariDataSource.addDataSourceProperty( "autoReconnect" , "true" );
     }
 
     /**

--- a/core/src/main/java/tr/zeltuv/ezql/objects/EzqlDatabase.java
+++ b/core/src/main/java/tr/zeltuv/ezql/objects/EzqlDatabase.java
@@ -62,6 +62,7 @@ public class EzqlDatabase {
         HikariConfig hikariConfig = customHikariSettings.getHikariConfig(credentials);
 
         hikariDataSource = new HikariDataSource(hikariConfig);
+        hikariDataSource.addDataSourceProperty( "autoReconnect" , "true" );
     }
 
     /**

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: EzChestShop
 version: ${project.version}
 main: me.deadlight.ezchestshop.EzChestShop
 api-version: 1.16
+folia-supported: true
 softdepend:
   - Vault
   - WildChests

--- a/craftbukkit_1_16_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_16_R1.java
+++ b/craftbukkit_1_16_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_16_R1.java
@@ -143,12 +143,12 @@ public class v1_16_R1 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());

--- a/craftbukkit_1_16_R2/src/main/java/me/deadlight/ezchestshop/utils/v1_16_R2.java
+++ b/craftbukkit_1_16_R2/src/main/java/me/deadlight/ezchestshop/utils/v1_16_R2.java
@@ -143,12 +143,12 @@ public class v1_16_R2 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());

--- a/craftbukkit_1_16_R3/src/main/java/me/deadlight/ezchestshop/utils/v1_16_R3.java
+++ b/craftbukkit_1_16_R3/src/main/java/me/deadlight/ezchestshop/utils/v1_16_R3.java
@@ -143,12 +143,12 @@ public class v1_16_R3 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());

--- a/craftbukkit_1_17_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_17_R1.java
+++ b/craftbukkit_1_17_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_17_R1.java
@@ -156,12 +156,12 @@ public class v1_17_R1 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());

--- a/craftbukkit_1_18_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_18_R1.java
+++ b/craftbukkit_1_18_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_18_R1.java
@@ -153,12 +153,12 @@ public class v1_18_R1 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());

--- a/craftbukkit_1_18_R2/src/main/java/me/deadlight/ezchestshop/utils/v1_18_R2.java
+++ b/craftbukkit_1_18_R2/src/main/java/me/deadlight/ezchestshop/utils/v1_18_R2.java
@@ -158,12 +158,12 @@ public class v1_18_R2 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());

--- a/craftbukkit_1_19_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_19_R1.java
+++ b/craftbukkit_1_19_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_19_R1.java
@@ -158,12 +158,12 @@ public class v1_19_R1 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());

--- a/craftbukkit_1_19_R2/src/main/java/me/deadlight/ezchestshop/utils/v1_19_R2.java
+++ b/craftbukkit_1_19_R2/src/main/java/me/deadlight/ezchestshop/utils/v1_19_R2.java
@@ -159,12 +159,12 @@ public class v1_19_R2 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());

--- a/craftbukkit_1_19_R3/src/main/java/me/deadlight/ezchestshop/utils/v1_19_R3.java
+++ b/craftbukkit_1_19_R3/src/main/java/me/deadlight/ezchestshop/utils/v1_19_R3.java
@@ -165,12 +165,12 @@ public class v1_19_R3 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTask(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTask(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());

--- a/craftbukkit_1_20_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_20_R1.java
+++ b/craftbukkit_1_20_R1/src/main/java/me/deadlight/ezchestshop/utils/v1_20_R1.java
@@ -162,12 +162,12 @@ public class v1_20_R1 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());

--- a/craftbukkit_1_20_R2/src/main/java/me/deadlight/ezchestshop/utils/v1_20_R2.java
+++ b/craftbukkit_1_20_R2/src/main/java/me/deadlight/ezchestshop/utils/v1_20_R2.java
@@ -170,12 +170,12 @@ public class v1_20_R2 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());

--- a/craftbukkit_1_20_R4/src/main/java/me/deadlight/ezchestshop/utils/v1_20_R4.java
+++ b/craftbukkit_1_20_R4/src/main/java/me/deadlight/ezchestshop/utils/v1_20_R4.java
@@ -170,12 +170,12 @@ public class v1_20_R4 extends VersionUtils {
                 boolean success = menu.getResponse().test(player, array);
 
                 if (!success && menu.isReopenIfFail() && !menu.isForceClose()) {
-                    Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
+                    EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> menu.open(player), 2L);
                 }
 
                 removeSignMenuFactoryListen(signMenuFactory);
 
-                Bukkit.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
+                EzChestShop.getScheduler().runTaskLater(EzChestShop.getPlugin(), () -> {
                     if (player.isOnline()) {
                         Location location = menu.getLocation();
                         player.sendBlockChange(location, location.getBlock().getBlockData());


### PR DESCRIPTION
Adds Folia Support to the plugin as requested by #61 

This should add Folia to the plugin, will need a better VersionUtils check for later as more Folia server versions come out (Added TODO: to each instance that VersionUtils ran so people will know where), currently set to work for 1.20.4 Folia.

As a small overview of what I did:
- Switched all schedules to the UniversalScheduler ones to support Folia (Could implement your own if you want less dependencies).
- Added "folia-supported: true" to the plugin.yml file so it doesn't auto-shutdown.
- Made a quick check if it's folia to use the 1.20.4 version (since it works generally) on all checks for VersionUtils.

NOTE: I haven't fully tested this out, but from the looks of it, there are no errors on boot and the detection of server versions does work, will need some actual testing to see if it works properly.