### PR TITLE
Fix disabled Buy/Sell text ignoring translations

### DIFF
--- a/core/src/main/java/me/deadlight/ezchestshop/data/LanguageManager.java
+++ b/core/src/main/java/me/deadlight/ezchestshop/data/LanguageManager.java
@@ -285,10 +285,10 @@ public class LanguageManager {
         return Utils.colorify(getString("shop-gui.buttons.settings"));
     }
     public String disabledButtonTitle() {
-        return Utils.colorify(getString("shop-gui.buttons.disabled-title"));
+        return Utils.colorify(getString("shop-gui.buttons.disabledButtonTitle"));
     }
     public List<String> disabledButtonLore() {
-        return getList("shop-gui.buttons.disabled-lore").stream().map(s -> Utils.colorify(s)).collect(Collectors.toList());
+        return getList("shop-gui.buttons.disabledButtonLore").stream().map(s -> Utils.colorify(s)).collect(Collectors.toList());
     }
 
 

--- a/core/src/main/resources/translations/Locale_CN.yml
+++ b/core/src/main/resources/translations/Locale_CN.yml
@@ -19,8 +19,8 @@ shop-gui:
     adminview: "&c&l管理庫存"
     storage: "&e&l庫存"
     settings: "&b&l設定"
-    disabled-title: "&c關閉"
-    disabled-lore: 
+    disabledButtonTitle: "&c關閉"
+    disabledButtonLore: 
       - "&7此選項已被商店主人關閉."
 transactions:
   transactionButtonTitle: "&a交易紀錄"

--- a/core/src/main/resources/translations/Locale_DE.yml
+++ b/core/src/main/resources/translations/Locale_DE.yml
@@ -22,9 +22,9 @@ shop-gui:
     adminview: "&c&lAdmin Sicht"
     storage: "&e&lLager"
     settings: "&b&lEinstellungen"
-    disabled-title: "&cDeaktiviert"
+    disabledButtonTitle: "&cDeaktiviert"
     # Verwende \n für eine neue Lorezeile (Bedenke neue Farben für jede Zeile zu verwenden)
-    disabled-lore:
+    disabledButtonLore:
       - "&7Diese Option ist vom "
       - " &7Shopbesitzer deaktiviert."
 transactions:

--- a/core/src/main/resources/translations/Locale_EN.yml
+++ b/core/src/main/resources/translations/Locale_EN.yml
@@ -19,8 +19,8 @@ shop-gui:
     adminview: "&c&lAdmin View"
     storage: "&e&lStorage"
     settings: "&b&lSettings"
-    disabled-title: "&cDisabled"
-    disabled-lore:
+    disabledButtonTitle: "&cDisabled"
+    disabledButtonLore:
       - "&7This option is disabled by "
       - " &7the shop owner."
 transactions:

--- a/core/src/main/resources/translations/Locale_FA.yml
+++ b/core/src/main/resources/translations/Locale_FA.yml
@@ -19,9 +19,9 @@ shop-gui:
     adminview: "&c&lAdmin View"
     storage: "&e&lAnbar"
     settings: "&b&lTanzimat"
-    disabled-title: "&cGheyre fa'al"
+    disabledButtonTitle: "&cGheyre fa'al"
     #Baraye Line Badi Az "\n" Estefade Konid. (remember to include color code in every line)
-    disabled-lore:
+    disabledButtonLore:
       - "&7In ghabeliat tavasot owner in shop "
       - " &7gheyre fa'al shode ast."
 transactions:

--- a/core/src/main/resources/translations/Locale_FR.yml
+++ b/core/src/main/resources/translations/Locale_FR.yml
@@ -19,8 +19,8 @@ shop-gui:
     adminview: "&c&lVue Admin"
     storage: "&e&lCapacitée"
     settings: "&b&lParamétres"
-    disabled-title: "&cDesactiver"
-    disabled-lore:
+    disabledButtonTitle: "&cDesactiver"
+    disabledButtonLore:
       - "&7Cette option est desactivée par "
       - " &7Le propriétaire."
 transactions:

--- a/core/src/main/resources/translations/Locale_PL.yml
+++ b/core/src/main/resources/translations/Locale_PL.yml
@@ -20,8 +20,8 @@ shop-gui:
     adminview: '&c&lPodgląd właściciela'
     storage: '&e&lPrzedmioty'
     settings: '&b&lUstawienia'
-    disabled-title: '&cWyłączony'
-    disabled-lore:
+    disabledButtonTitle: '&cWyłączony'
+    disabledButtonLore:
       - '&7Ta opcja została wyłączona przez '
       - ' &7właściciela sklepu.'
 transactions:

--- a/core/src/main/resources/translations/Locale_RU.yml
+++ b/core/src/main/resources/translations/Locale_RU.yml
@@ -19,8 +19,8 @@ shop-gui:
     adminview: "&c&lПросмотр администратора"
     storage: "&e&lХранение"
     settings: "&b&lНастройка"
-    disabled-title: "&cВыключено"
-    disabled-lore:
+    disabledButtonTitle: "&cВыключено"
+    disabledButtonLore:
       - "&7Этот параметр выключен "
       - " &7владельцем магазина."
 transactions:

--- a/core/src/main/resources/translations/Locale_SK.yml
+++ b/core/src/main/resources/translations/Locale_SK.yml
@@ -19,8 +19,8 @@ shop-gui:
     adminview: "&c&lZobrazenie správcu servera"
     storage: "&e&lSklad"
     settings: "&b&lNastavenia"
-    disabled-title: "&cZakázané"
-    disabled-lore:
+    disabledButtonTitle: "&cZakázané"
+    disabledButtonLore:
       - "&7Táto funkcia je zakázaná"
       - " &7najiteľom obchodu."
 transactions:

--- a/core/src/main/resources/translations/Locale_TR.yml
+++ b/core/src/main/resources/translations/Locale_TR.yml
@@ -20,8 +20,8 @@ shop-gui:
     adminview: "&cStok Takibi"
     storage: "&6Depo"
     settings: "&bAyarlar"
-    disabled-title: "&cMarkete ürün satamazsın!"
-    disabled-lore:
+    disabledButtonTitle: "&cMarkete ürün satamazsın!"
+    disabledButtonLore:
       - ""
       - "&7Bu seçenek market sahibi"
       - "&7tarafından devre dışı bırakıldı!"

--- a/core/src/main/resources/translations/Locale_UA.yml
+++ b/core/src/main/resources/translations/Locale_UA.yml
@@ -19,8 +19,8 @@ shop-gui:
     adminview: "&c&lПерегляд адміністратора"
     storage: "&e&lЗберігання"
     settings: "&b&lНалаштування"
-    disabled-title: "&cВимкнено"
-    disabled-lore:
+    disabledButtonTitle: "&cВимкнено"
+    disabledButtonLore:
       - "&7Цей параметр вимкнено "
       - " &7власником магазину."
 transactions:

--- a/core/src/main/resources/translations/Locale_VI.yml
+++ b/core/src/main/resources/translations/Locale_VI.yml
@@ -19,8 +19,8 @@ shop-gui:
     adminview: "&cTrang xem của admin"
     storage: "&eKho Chứa"
     settings: "&bCài đặt"
-    disabled-title: "&cĐã tắt"
-    disabled-lore:
+    disabledButtonTitle: "&cĐã tắt"
+    disabledButtonLore:
       - "&7Lựa chọn này đã bị tắt"
       - " &7bởi chủ shop."
 transactions:


### PR DESCRIPTION
Fixes #67

This PR fixes the issue where disabled Buy/Sell buttons display hardcoded text instead of using translations.

## Changes
- Updated the LanguageManager class to use consistent key names for disabled button title and lore
- Updated all language files to use the same key format (`disabledButtonTitle` and `disabledButtonLore` instead of `disabled-title` and `disabled-lore`)

This ensures that all language files use the same key format, and the LanguageManager class correctly retrieves the translations for the disabled Buy/Sell buttons.